### PR TITLE
Enable manual path entry for Archive Packer input/output fields

### DIFF
--- a/master/ArchivePacker.Designer.cs
+++ b/master/ArchivePacker.Designer.cs
@@ -125,18 +125,18 @@
             this.textBox1.Location = new System.Drawing.Point(104, 86);
             this.textBox1.Margin = new System.Windows.Forms.Padding(2);
             this.textBox1.Name = "textBox1";
-            this.textBox1.ReadOnly = true;
             this.textBox1.Size = new System.Drawing.Size(283, 20);
             this.textBox1.TabIndex = 3;
+            this.textBox1.Leave += new System.EventHandler(this.textBox1_Leave);
             // 
             // textBox2
             // 
             this.textBox2.Location = new System.Drawing.Point(104, 117);
             this.textBox2.Margin = new System.Windows.Forms.Padding(2);
             this.textBox2.Name = "textBox2";
-            this.textBox2.ReadOnly = true;
             this.textBox2.Size = new System.Drawing.Size(283, 20);
             this.textBox2.TabIndex = 4;
+            this.textBox2.Leave += new System.EventHandler(this.textBox2_Leave);
             // 
             // button1
             // 

--- a/master/ArchivePacker.cs
+++ b/master/ArchivePacker.cs
@@ -812,6 +812,12 @@ namespace TTG_Tools
             }
         }
 
+        private void textBox1_Leave(object sender, EventArgs e)
+        {
+            MainMenu.settings.inputDirPath = textBox1.Text.Trim();
+            Settings.SaveConfig(MainMenu.settings);
+        }
+
         private void button2_Click(object sender, EventArgs e)
         {
             if (ttarchRB.Checked)
@@ -844,6 +850,12 @@ namespace TTG_Tools
                     textBox2.Clear();
                 }
             }
+        }
+
+        private void textBox2_Leave(object sender, EventArgs e)
+        {
+            MainMenu.settings.archivePath = textBox2.Text.Trim();
+            Settings.SaveConfig(MainMenu.settings);
         }
 
         private async void buildButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
### Motivation
- Allow users to type full paths into the `Input folder` and `Output archive` fields instead of being forced to use the browse dialogs.
- Ensure manually entered paths are persisted to the application settings so they behave the same as dialog-selected paths.

### Description
- Removed the `ReadOnly` behavior from `textBox1` and `textBox2` in `ArchivePacker.Designer.cs` to allow typing.
- Added `Leave` event handlers `textBox1_Leave` and `textBox2_Leave` in `ArchivePacker.cs` which save trimmed values into `MainMenu.settings` via `Settings.SaveConfig`.
- Kept existing `...` browse-button handlers intact so dialog selection continues to populate and save the paths as before.