### PR TITLE
Add drag-and-drop path filling in Archive Packer

### DIFF
--- a/master/ArchivePacker.Designer.cs
+++ b/master/ArchivePacker.Designer.cs
@@ -122,21 +122,27 @@
             // 
             // textBox1
             // 
+            this.textBox1.AllowDrop = true;
             this.textBox1.Location = new System.Drawing.Point(104, 86);
             this.textBox1.Margin = new System.Windows.Forms.Padding(2);
             this.textBox1.Name = "textBox1";
-            this.textBox1.ReadOnly = true;
             this.textBox1.Size = new System.Drawing.Size(283, 20);
             this.textBox1.TabIndex = 3;
+            this.textBox1.DragDrop += new System.Windows.Forms.DragEventHandler(this.textBox1_DragDrop);
+            this.textBox1.DragEnter += new System.Windows.Forms.DragEventHandler(this.textBox_DragEnter);
+            this.textBox1.Leave += new System.EventHandler(this.textBox1_Leave);
             // 
             // textBox2
             // 
+            this.textBox2.AllowDrop = true;
             this.textBox2.Location = new System.Drawing.Point(104, 117);
             this.textBox2.Margin = new System.Windows.Forms.Padding(2);
             this.textBox2.Name = "textBox2";
-            this.textBox2.ReadOnly = true;
             this.textBox2.Size = new System.Drawing.Size(283, 20);
             this.textBox2.TabIndex = 4;
+            this.textBox2.DragDrop += new System.Windows.Forms.DragEventHandler(this.textBox2_DragDrop);
+            this.textBox2.DragEnter += new System.Windows.Forms.DragEventHandler(this.textBox_DragEnter);
+            this.textBox2.Leave += new System.EventHandler(this.textBox2_Leave);
             // 
             // button1
             // 

--- a/master/ArchivePacker.cs
+++ b/master/ArchivePacker.cs
@@ -812,6 +812,12 @@ namespace TTG_Tools
             }
         }
 
+        private void textBox1_Leave(object sender, EventArgs e)
+        {
+            MainMenu.settings.inputDirPath = textBox1.Text.Trim();
+            Settings.SaveConfig(MainMenu.settings);
+        }
+
         private void button2_Click(object sender, EventArgs e)
         {
             if (ttarchRB.Checked)
@@ -844,6 +850,62 @@ namespace TTG_Tools
                     textBox2.Clear();
                 }
             }
+        }
+
+        private void textBox2_Leave(object sender, EventArgs e)
+        {
+            MainMenu.settings.archivePath = textBox2.Text.Trim();
+            Settings.SaveConfig(MainMenu.settings);
+        }
+
+        private void textBox_DragEnter(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop)) e.Effect = DragDropEffects.Copy;
+            else e.Effect = DragDropEffects.None;
+        }
+
+        private static string GetDroppedPath(DragEventArgs e)
+        {
+            string[] droppedItems = e.Data.GetData(DataFormats.FileDrop) as string[];
+            if (droppedItems == null || droppedItems.Length == 0) return string.Empty;
+
+            return droppedItems[0];
+        }
+
+        private void textBox1_DragDrop(object sender, DragEventArgs e)
+        {
+            string droppedPath = GetDroppedPath(e);
+            if (droppedPath == string.Empty) return;
+
+            if (File.Exists(droppedPath)) droppedPath = Path.GetDirectoryName(droppedPath);
+
+            if (Directory.Exists(droppedPath))
+            {
+                textBox1.Text = droppedPath;
+                MainMenu.settings.inputDirPath = droppedPath;
+                Settings.SaveConfig(MainMenu.settings);
+            }
+        }
+
+        private string GetDefaultOutputArchivePath(string droppedPath)
+        {
+            if (File.Exists(droppedPath)) return droppedPath;
+
+            if (!Directory.Exists(droppedPath)) return string.Empty;
+
+            string archiveName = new DirectoryInfo(droppedPath).Name;
+            string extension = ttarchRB.Checked ? ".ttarch" : ".ttarch2";
+            return Path.Combine(droppedPath, archiveName + extension);
+        }
+
+        private void textBox2_DragDrop(object sender, DragEventArgs e)
+        {
+            string outputArchivePath = GetDefaultOutputArchivePath(GetDroppedPath(e));
+            if (outputArchivePath == string.Empty) return;
+
+            textBox2.Text = outputArchivePath;
+            MainMenu.settings.archivePath = outputArchivePath;
+            Settings.SaveConfig(MainMenu.settings);
         }
 
         private async void buildButton_Click(object sender, EventArgs e)


### PR DESCRIPTION
### Motivation
- Provide a Windows-like convenience so users can quickly populate `Input folder` and `Output archive` by dragging a file or folder onto those fields. 
- Preserve manual-typing and browse-button flows while ensuring any populated path is persisted to application settings.

### Description
- Enabled `AllowDrop` and hooked `DragEnter`/`DragDrop` events for `textBox1` and `textBox2` in `ArchivePacker.Designer.cs` so the controls accept drops. 
- Implemented `textBox_DragEnter`, `GetDroppedPath`, `textBox1_DragDrop`, `textBox2_DragDrop` and `GetDefaultOutputArchivePath` in `ArchivePacker.cs` to accept a dropped file or folder, map files to their parent folder for input, and generate a sensible archive path for folder drops (extension chosen by `ttarchRB.Checked`). 
- Kept the existing `Leave` handlers and browse-button handlers and persist values via `Settings.SaveConfig(MainMenu.settings)` identical to manual entry.