### PR TITLE
Add drag-and-drop input path support to ArchivePacker

### DIFF
--- a/master/ArchivePacker.cs
+++ b/master/ArchivePacker.cs
@@ -729,6 +729,13 @@ namespace TTG_Tools
 
         private void ArchivePacker_Load(object sender, EventArgs e)
         {
+            AllowDrop = true;
+            DragEnter += ArchivePacker_DragEnter;
+            DragDrop += ArchivePacker_DragDrop;
+            textBox1.AllowDrop = true;
+            textBox1.DragEnter += ArchivePacker_DragEnter;
+            textBox1.DragDrop += ArchivePacker_DragDrop;
+
             for (int i = 0; i < MainMenu.gamelist.Count(); i++)
             {
                 comboGameList.Items.Add(i + ". " + MainMenu.gamelist[i].gamename);
@@ -855,6 +862,36 @@ namespace TTG_Tools
         private void textBox2_Leave(object sender, EventArgs e)
         {
             MainMenu.settings.archivePath = textBox2.Text.Trim();
+            Settings.SaveConfig(MainMenu.settings);
+        }
+
+        private void ArchivePacker_DragEnter(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                e.Effect = DragDropEffects.Copy;
+            }
+            else
+            {
+                e.Effect = DragDropEffects.None;
+            }
+        }
+
+        private void ArchivePacker_DragDrop(object sender, DragEventArgs e)
+        {
+            string[] droppedItems = e.Data.GetData(DataFormats.FileDrop) as string[];
+            if ((droppedItems == null) || (droppedItems.Length == 0)) return;
+
+            string droppedPath = droppedItems[0];
+            string inputDirectory = null;
+
+            if (Directory.Exists(droppedPath)) inputDirectory = droppedPath;
+            else if (File.Exists(droppedPath)) inputDirectory = Path.GetDirectoryName(droppedPath);
+
+            if (string.IsNullOrWhiteSpace(inputDirectory)) return;
+
+            textBox1.Text = inputDirectory;
+            MainMenu.settings.inputDirPath = inputDirectory.Trim();
             Settings.SaveConfig(MainMenu.settings);
         }
 


### PR DESCRIPTION
### Motivation
- For convenience, allow users to drop a folder or a file onto the ArchivePacker UI so the input directory is filled automatically, matching the Windows behavior described.

### Description
- Enabled drag-and-drop on the `ArchivePacker` form and on the input folder textbox (`textBox1`) and registered `DragEnter` and `DragDrop` handlers.
- Implemented `ArchivePacker_DragEnter` to accept only `FileDrop` data and set the proper `DragDropEffects`.
- Implemented `ArchivePacker_DragDrop` to resolve the dropped item into an input directory by using the dropped folder directly or the parent directory when a file is dropped, then update `textBox1` and `MainMenu.settings.inputDirPath`.
- Persist the resolved input path immediately by calling `Settings.SaveConfig(MainMenu.settings)`.