### PR TITLE
Enable Archive Packer minimization and fix Xbox 360 swizzle persistence

### DIFF
--- a/master/ArchivePacker.Designer.cs
+++ b/master/ArchivePacker.Designer.cs
@@ -391,7 +391,7 @@
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Margin = new System.Windows.Forms.Padding(2);
             this.MaximizeBox = false;
-            this.MinimizeBox = false;
+            this.MinimizeBox = true;
             this.Name = "ArchivePacker";
             this.Text = "Archive packer";
             this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.ArchivePacker_FormClosing);

--- a/master/AutoPacker.cs
+++ b/master/AutoPacker.cs
@@ -340,6 +340,7 @@ namespace TTG_Tools
             {
                 MainMenu.settings.swizzleNintendoSwitch = false;
                 MainMenu.settings.swizzlePS4 = false;
+                MainMenu.settings.swizzleXbox360 = false;
                 Settings.SaveConfig(MainMenu.settings);
             }
         }


### PR DESCRIPTION
### Motivation
- Allow the Archive Packer window to be minimized instead of only closed to improve usability.
- Fix a bug where selecting `None` for swizzle in AutoDePacker did not clear the Xbox 360 flag, causing the Xbox 360 swizzle to reappear after closing/reopening.

### Description
- Set `MinimizeBox = true` in `ArchivePacker.Designer.cs` so the Archive Packer form can be minimized.
- In `AutoPacker.cs` updated `rbNoSwizzle_CheckedChanged` to also set `MainMenu.settings.swizzleXbox360 = false` and then call `Settings.SaveConfig(MainMenu.settings)` to persist the "None" choice.