### PR TITLE
Add drag-and-drop and real-time combined search/filter to Archive Unpacker

### DIFF
--- a/master/ArchiveUnpacker.Designer.cs
+++ b/master/ArchiveUnpacker.Designer.cs
@@ -286,6 +286,7 @@
             this.searchTB.Name = "searchTB";
             this.searchTB.Size = new System.Drawing.Size(415, 20);
             this.searchTB.TabIndex = 13;
+            this.searchTB.TextChanged += new System.EventHandler(this.searchTB_TextChanged);
             // 
             // searchBtn
             // 
@@ -301,6 +302,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AllowDrop = true;
             this.ClientSize = new System.Drawing.Size(978, 696);
             this.Controls.Add(this.searchBtn);
             this.Controls.Add(this.searchTB);
@@ -322,6 +324,8 @@
             this.MaximizeBox = false;
             this.Name = "ArchiveUnpacker";
             this.Text = "Archive unpacker";
+            this.DragDrop += new System.Windows.Forms.DragEventHandler(this.ArchiveUnpacker_DragDrop);
+            this.DragEnter += new System.Windows.Forms.DragEventHandler(this.ArchiveUnpacker_DragEnter);
             this.Load += new System.EventHandler(this.ArchiveUnpacker_Load);
             this.menuStrip1.ResumeLayout(false);
             this.menuStrip1.PerformLayout();


### PR DESCRIPTION
### Motivation

- Melhorar a usabilidade do Archive Unpacker adicionando suporte a drag-and-drop para abrir arquivos de arquivo e permitindo pesquisa em tempo real na lista de arquivos; e
- Fazer com que o filtro `File formats` funcione em conjunto com a pesquisa por nome (antes a pesquisa era ignorada quando o filtro era aplicado).

### Description

- Adicionado suporte de arrastar-e-soltar na janela (`AllowDrop`, eventos `DragEnter` e `DragDrop`) e integrado ao mesmo fluxo de abertura de arquivo reutilizável (`OpenArchiveFile`).
- Refatorado o fluxo de abertura para um método assíncrono `OpenArchiveFile(string)` e extraído helper `populateFileFormats(List<string>)` para popular o `fileFormatsCB` de forma centralizada.
- Implementada busca em tempo real ligando `searchTB.TextChanged` a `applyFilters()`, que aplica simultaneamente o filtro de formato e o filtro de texto usando `getFilteredTtarchFiles()` e `getFilteredTtarch2Files()`.
- Atualizados `UnpackTtarch` e `UnpackTtarch2` para operar sobre o conjunto filtrado (o mesmo que é mostrado na grid), e removidas funções/flags de pesquisa antigas para consolidar a nova lógica; `fileFormatsCB.SelectedIndexChanged` agora chama `applyFilters()`.