### PR TITLE
Fix ArchiveUnpacker exception when filter/search returns no results

### DIFF
--- a/master/ArchiveUnpacker.cs
+++ b/master/ArchiveUnpacker.cs
@@ -15,6 +15,7 @@ namespace TTG_Tools
         public ArchiveUnpacker()
         {
             InitializeComponent();
+            filesDataGridView.AllowUserToAddRows = false;
         }
 
         private static ClassesStructs.TtarchClass ttarch;
@@ -878,7 +879,7 @@ namespace TTG_Tools
             filesDataGridView.Columns[2].HeaderText = "File offset";
             filesDataGridView.Columns[3].HeaderText = "File size";
 
-            filesDataGridView.RowCount = files.Length;
+            filesDataGridView.RowCount = Math.Max(1, files.Length);
 
             int maxnameLen = 0;
             int maxOffLen = 0;
@@ -915,7 +916,7 @@ namespace TTG_Tools
             filesDataGridView.Columns[2].HeaderText = "File offset";
             filesDataGridView.Columns[3].HeaderText = "File size";
 
-            filesDataGridView.RowCount = files.Length;
+            filesDataGridView.RowCount = Math.Max(1, files.Length);
 
             int maxnameLen = 0;
             int maxOffLen = 0;
@@ -1105,7 +1106,7 @@ namespace TTG_Tools
             filesDataGridView.Columns[2].HeaderText = "File offset";
             filesDataGridView.Columns[3].HeaderText = "File size";
 
-            filesDataGridView.RowCount = files.Length;
+            filesDataGridView.RowCount = Math.Max(1, files.Length);
 
             int maxnameLen = 0;
             int maxOffLen = 0;
@@ -1142,7 +1143,7 @@ namespace TTG_Tools
             filesDataGridView.Columns[2].HeaderText = "File offset";
             filesDataGridView.Columns[3].HeaderText = "File size";
 
-            filesDataGridView.RowCount = files.Length;
+            filesDataGridView.RowCount = Math.Max(1, files.Length);
 
             int maxnameLen = 0;
             int maxOffLen = 0;


### PR DESCRIPTION
### Motivation
- Prevent an `ArgumentOutOfRangeException` in the Archive Unpacker when a filter/search returns zero files because `DataGridView.RowCount` was being set to 0.
- Ensure the manually-populated `filesDataGridView` does not include the automatic user-add row which conflicts with manual population logic.

### Description
- Set `filesDataGridView.AllowUserToAddRows = false;` in the `ArchiveUnpacker` constructor to disable the automatic new-row placeholder.
- Replace assignments of `filesDataGridView.RowCount = files.Length;` with `filesDataGridView.RowCount = Math.Max(1, files.Length);` in all TTARCH/TTARCH2 loader overloads to ensure `RowCount` never becomes 0.
- Changes are limited to `master/ArchiveUnpacker.cs` and only affect the table population logic for `loadTtarchData` and `loadTtarch2Data` variants.