### PR TITLE
Add configurable UI language support and external translation file

### DIFF
--- a/master/FormSettings.Designer.cs
+++ b/master/FormSettings.Designer.cs
@@ -49,6 +49,8 @@
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.checkLanguage = new System.Windows.Forms.CheckBox();
             this.languageComboBox = new System.Windows.Forms.ComboBox();
+            this.labelInterfaceLanguage = new System.Windows.Forms.Label();
+            this.interfaceLanguageComboBox = new System.Windows.Forms.ComboBox();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDownASCII)).BeginInit();
             this.groupBox2.SuspendLayout();
             this.groupBox1.SuspendLayout();
@@ -243,11 +245,31 @@
             this.languageComboBox.Size = new System.Drawing.Size(199, 21);
             this.languageComboBox.TabIndex = 32;
             // 
+            // 
+            // labelInterfaceLanguage
+            // 
+            this.labelInterfaceLanguage.AutoSize = true;
+            this.labelInterfaceLanguage.Location = new System.Drawing.Point(19, 81);
+            this.labelInterfaceLanguage.Name = "labelInterfaceLanguage";
+            this.labelInterfaceLanguage.Size = new System.Drawing.Size(94, 13);
+            this.labelInterfaceLanguage.TabIndex = 33;
+            this.labelInterfaceLanguage.Text = "Interface language:";
+            // 
+            // interfaceLanguageComboBox
+            // 
+            this.interfaceLanguageComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.interfaceLanguageComboBox.FormattingEnabled = true;
+            this.interfaceLanguageComboBox.Location = new System.Drawing.Point(247, 78);
+            this.interfaceLanguageComboBox.Name = "interfaceLanguageComboBox";
+            this.interfaceLanguageComboBox.Size = new System.Drawing.Size(199, 21);
+            this.interfaceLanguageComboBox.TabIndex = 34;
             // FormSettings
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(475, 368);
+            this.Controls.Add(this.interfaceLanguageComboBox);
+            this.Controls.Add(this.labelInterfaceLanguage);
             this.Controls.Add(this.languageComboBox);
             this.Controls.Add(this.checkLanguage);
             this.Controls.Add(this.groupBox1);
@@ -295,5 +317,7 @@
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.CheckBox checkLanguage;
         private System.Windows.Forms.ComboBox languageComboBox;
+        private System.Windows.Forms.Label labelInterfaceLanguage;
+        private System.Windows.Forms.ComboBox interfaceLanguageComboBox;
     }
 }

--- a/master/FormSettings.cs
+++ b/master/FormSettings.cs
@@ -6,6 +6,17 @@ namespace TTG_Tools
 {
     public partial class FormSettings : Form
     {
+        private class LanguageOption
+        {
+            public string Code { get; set; }
+            public string DisplayName { get; set; }
+
+            public override string ToString()
+            {
+                return DisplayName;
+            }
+        }
+
         public FormSettings()
         {
             InitializeComponent();
@@ -35,7 +46,10 @@ namespace TTG_Tools
             MainMenu.settings.ASCII_N = (int)numericUpDownASCII.Value;
             MainMenu.settings.pathForInputFolder = textBoxInputFolder.Text;
             MainMenu.settings.pathForOutputFolder = textBoxOutputFolder.Text;
-            
+
+            LanguageOption selectedUiLanguage = interfaceLanguageComboBox.SelectedItem as LanguageOption;
+            MainMenu.settings.uiLanguageCode = selectedUiLanguage != null ? selectedUiLanguage.Code : "en";
+
             if (rbNormalUnicode.Checked == true) MainMenu.settings.unicodeSettings = 0;
             else if (rbNonNormalUnicode2.Checked == true) MainMenu.settings.unicodeSettings = 1;
             else MainMenu.settings.unicodeSettings = 2;
@@ -46,17 +60,17 @@ namespace TTG_Tools
                 MainMenu.settings.languageIndex = languageComboBox.SelectedIndex;
 
                 string selectedLanguage = languageComboBox.Text;
-                
+
                 // Check if text contains parentheses to extract ASCII code
                 if (selectedLanguage.Contains("(") && selectedLanguage.Contains(")"))
                 {
                     int start = selectedLanguage.IndexOf("(") + 1;
                     int end = selectedLanguage.IndexOf(")");
-                    
+
                     if (start < end && start > 0)
                     {
                         string str_num = selectedLanguage.Substring(start, end - start).Trim();
-                        
+
                         if (int.TryParse(str_num, out int asciiValue) && asciiValue > 0)
                         {
                             MainMenu.settings.ASCII_N = asciiValue;
@@ -88,13 +102,13 @@ namespace TTG_Tools
 
                 if (Program.FirstTime)
                 {
-                    MessageBox.Show("Please restart application to confirm settings");
+                    MessageBox.Show(UiLocalizer.Get("Settings.RestartMessage"));
                     this.Close();
                 }
             }
             else
             {
-                MessageBox.Show("Please set correct paths for input and output folders!");
+                MessageBox.Show(UiLocalizer.Get("Settings.InvalidPathsMessage"));
             }
         }
 
@@ -190,7 +204,7 @@ namespace TTG_Tools
         private void numericUpDownASCII_ValueChanged(object sender, EventArgs e)
         {
             int asciiValue = (int)numericUpDownASCII.Value;
-            
+
             switch (asciiValue)
             {
                 case 873:
@@ -251,6 +265,31 @@ namespace TTG_Tools
             languageComboBox.Enabled = MainMenu.settings.languageIndex != -1;
             languageComboBox.SelectedIndex = MainMenu.settings.languageIndex != -1 ? languageComboBox.SelectedIndex = MainMenu.settings.languageIndex : 0;
 
+            interfaceLanguageComboBox.Items.Clear();
+            foreach (string code in UiLocalizer.AvailableLanguages)
+            {
+                interfaceLanguageComboBox.Items.Add(new LanguageOption
+                {
+                    Code = code,
+                    DisplayName = UiLocalizer.GetLanguageDisplayName(code)
+                });
+            }
+
+            string currentLanguage = string.IsNullOrWhiteSpace(MainMenu.settings.uiLanguageCode) ? UiLocalizer.CurrentLanguageCode : MainMenu.settings.uiLanguageCode;
+            for (int i = 0; i < interfaceLanguageComboBox.Items.Count; i++)
+            {
+                LanguageOption option = interfaceLanguageComboBox.Items[i] as LanguageOption;
+                if (option != null && option.Code.Equals(currentLanguage, StringComparison.OrdinalIgnoreCase))
+                {
+                    interfaceLanguageComboBox.SelectedIndex = i;
+                    break;
+                }
+            }
+            if (interfaceLanguageComboBox.SelectedIndex == -1 && interfaceLanguageComboBox.Items.Count > 0)
+            {
+                interfaceLanguageComboBox.SelectedIndex = 0;
+            }
+
             switch (MainMenu.settings.unicodeSettings)
             {
                 case 1:
@@ -263,6 +302,8 @@ namespace TTG_Tools
                     rbNormalUnicode.Checked = true;
                     break;
             }
+
+            UiLocalizer.ApplyToFormSettings(this);
         }
 
         private void buttonInputFolder_Click(object sender, EventArgs e)
@@ -278,7 +319,43 @@ namespace TTG_Tools
         private void checkLanguage_CheckedChanged(object sender, EventArgs e)
         {
             languageComboBox.SelectedIndex = 0;
-            languageComboBox.Enabled = checkLanguage.Checked;            
+            languageComboBox.Enabled = checkLanguage.Checked;
+        }
+
+        public void SetLocalizedTexts(
+            string asciiLabel,
+            string applyAndExit,
+            string apply,
+            string exit,
+            string inputFolder,
+            string outputFolder,
+            string pathsGroup,
+            string detectLanguageCheckbox,
+            string interfaceLanguageLabel,
+            string unicodeGroup,
+            string normalUnicode,
+            string nonNormalUnicode,
+            string newBttFUnicode,
+            string normalUnicodeTooltip,
+            string nonNormalUnicodeTooltip,
+            string newBttFUnicodeTooltip)
+        {
+            label1.Text = asciiLabel;
+            buttonApplyAndExitSettings.Text = applyAndExit;
+            buttonSaveSettings.Text = apply;
+            buttonExitSettingsForm.Text = exit;
+            buttonInputFolder.Text = inputFolder;
+            buttonOutputFolder.Text = outputFolder;
+            groupBox1.Text = pathsGroup;
+            checkLanguage.Text = detectLanguageCheckbox;
+            labelInterfaceLanguage.Text = interfaceLanguageLabel;
+            groupBox2.Text = unicodeGroup;
+            rbNormalUnicode.Text = normalUnicode;
+            rbNonNormalUnicode2.Text = nonNormalUnicode;
+            rbNewBttF.Text = newBttFUnicode;
+            toolTip1.SetToolTip(rbNormalUnicode, normalUnicodeTooltip);
+            toolTip2.SetToolTip(rbNonNormalUnicode2, nonNormalUnicodeTooltip);
+            toolTip3.SetToolTip(rbNewBttF, newBttFUnicodeTooltip);
         }
     }
 }

--- a/master/MainMenu.cs
+++ b/master/MainMenu.cs
@@ -10,7 +10,7 @@ namespace TTG_Tools
 {
     public partial class MainMenu : Form
     {
-        public static Settings settings = new Settings("", "", 1251, false, false, false, true, false, 0, false, false, false, false, false, false, 0, 0, "", "", "", false, false, false, false, 0, 0, false, false, false, false, false, false, false, -1);
+        public static Settings settings = new Settings("", "", 1251, false, false, false, true, false, 0, false, false, false, false, false, false, 0, 0, "", "", "", false, false, false, false, 0, 0, false, false, false, false, false, false, false, -1, "en");
 
         [DllImport("kernel32.dll")]
         public static extern void SetProcessWorkingSetSize(IntPtr hWnd, int i, int j);

--- a/master/Program.cs
+++ b/master/Program.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Windows.Forms;
 using System.IO;
+using System.Xml;
+using System.Xml.Serialization;
 
 namespace TTG_Tools
 {
@@ -18,13 +20,30 @@ namespace TTG_Tools
             {
                 FirstTime = false;
 
+                Settings loadedSettings = null;
+                try
+                {
+                    using (XmlReader reader = new XmlTextReader(xmlPath))
+                    {
+                        XmlSerializer settingsDeserializer = new XmlSerializer(typeof(Settings));
+                        loadedSettings = (Settings)settingsDeserializer.Deserialize(reader);
+                    }
+                }
+                catch
+                {
+                    loadedSettings = null;
+                }
+
+                UiLocalizer.Initialize(loadedSettings != null ? loadedSettings.uiLanguageCode : "en");
+
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
                 Application.Run(new MainMenu());
             }
             else
             {
-                MessageBox.Show("Can't find config.xml!\r\nPlease set path for folders, save changes and restart the program!", "Error");
+                UiLocalizer.Initialize("en");
+                MessageBox.Show(UiLocalizer.Get("Program.MissingConfigMessage"), UiLocalizer.Get("Program.MissingConfigTitle"));
                 Application.EnableVisualStyles();
                 Application.SetCompatibleTextRenderingDefault(false);
                 Application.Run(new FormSettings());

--- a/master/Settings.cs
+++ b/master/Settings.cs
@@ -54,6 +54,7 @@ namespace TTG_Tools
         private bool _swizzleXbox360;
 
         private int _languageIndex;
+        private string _uiLanguageCode;
 
         [XmlAttribute("pathForInputFolder")]
         public string pathForInputFolder
@@ -485,6 +486,20 @@ namespace TTG_Tools
             }
         }
 
+
+        [XmlAttribute("uiLanguageCode")]
+        public string uiLanguageCode
+        {
+            get
+            {
+                return _uiLanguageCode;
+            }
+            set
+            {
+                _uiLanguageCode = value;
+            }
+        }
+
         [XmlAttribute("ASCIILanguageIndex")]
         public int languageIndex
         {
@@ -532,7 +547,8 @@ namespace TTG_Tools
             bool _ignoreEmptyStrings,
             bool _swizzlePS4,
             bool _swizzleXbox360,
-            int _languageIndex)
+            int _languageIndex,
+            string _uiLanguageCode)
         {
             this.ASCII_N = _ASCII_N;
             this.pathForInputFolder = _pathForInputFolder;
@@ -568,6 +584,7 @@ namespace TTG_Tools
             this.swizzlePS4 = _swizzlePS4;
             this.swizzleXbox360 = _swizzleXbox360;
             this.languageIndex = _languageIndex;
+            this.uiLanguageCode = _uiLanguageCode;
         }
 
         public Settings()

--- a/master/TTG Tools.csproj
+++ b/master/TTG Tools.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Texts\LangdbWorker.cs" />
     <Compile Include="Texts\ReadText.cs" />
     <Compile Include="Texts\SaveText.cs" />
+    <Compile Include="Texts\UiLocalizer.cs" />
     <Compile Include="Wrapper\OodleTools.cs" />
     <EmbeddedResource Include="About.resx">
       <DependentUpon>About.cs</DependentUpon>
@@ -225,6 +226,9 @@
   <ItemGroup>
     <None Include="Resources\IconSave.ico" />
     <Content Include="ttgtool.ico" />
+    <Content Include="Translations\ui-translations.xml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <BootstrapperPackage Include="Microsoft.Net.Client.3.5">

--- a/master/Texts/UiLocalizer.cs
+++ b/master/Texts/UiLocalizer.cs
@@ -1,0 +1,142 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Xml.Linq;
+using System.Windows.Forms;
+
+namespace TTG_Tools
+{
+    public static class UiLocalizer
+    {
+        private const string DefaultLanguageCode = "en";
+        private static readonly Dictionary<string, Dictionary<string, string>> _translations =
+            new Dictionary<string, Dictionary<string, string>>(StringComparer.OrdinalIgnoreCase);
+
+        private static bool _loaded;
+
+        public static IReadOnlyList<string> AvailableLanguages
+        {
+            get { EnsureLoaded(); return _translations.Keys.OrderBy(x => x).ToList(); }
+        }
+
+        public static string CurrentLanguageCode { get; private set; } = DefaultLanguageCode;
+
+        public static void Initialize(string languageCode)
+        {
+            EnsureLoaded();
+
+            if (!string.IsNullOrWhiteSpace(languageCode) && _translations.ContainsKey(languageCode))
+            {
+                CurrentLanguageCode = languageCode;
+            }
+            else
+            {
+                CurrentLanguageCode = DefaultLanguageCode;
+            }
+        }
+
+        public static string Get(string key)
+        {
+            EnsureLoaded();
+
+            if (_translations.TryGetValue(CurrentLanguageCode, out var selectedLanguage) && selectedLanguage.TryGetValue(key, out var text))
+            {
+                return text;
+            }
+
+            if (_translations.TryGetValue(DefaultLanguageCode, out var fallbackLanguage) && fallbackLanguage.TryGetValue(key, out var fallbackText))
+            {
+                return fallbackText;
+            }
+
+            return key;
+        }
+
+        public static string GetLanguageDisplayName(string code)
+        {
+            EnsureLoaded();
+
+            if (_translations.TryGetValue(code, out var language) && language.TryGetValue("LanguageName", out var name))
+            {
+                return name;
+            }
+
+            return code;
+        }
+
+        public static void ApplyToFormSettings(FormSettings form)
+        {
+            form.Text = Get("Settings.FormTitle");
+            form.SetLocalizedTexts(
+                Get("Settings.AsciiLabel"),
+                Get("Settings.ApplyAndExitButton"),
+                Get("Settings.ApplyButton"),
+                Get("Settings.ExitButton"),
+                Get("Settings.InputFolderButton"),
+                Get("Settings.OutputFolderButton"),
+                Get("Settings.PathsGroup"),
+                Get("Settings.DetectLanguageCheckbox"),
+                Get("Settings.InterfaceLanguageLabel"),
+                Get("Settings.UnicodeGroup"),
+                Get("Settings.NormalUnicode"),
+                Get("Settings.NonNormalUnicode"),
+                Get("Settings.NewBttFUnicode"),
+                Get("Settings.NormalUnicodeTooltip"),
+                Get("Settings.NonNormalUnicodeTooltip"),
+                Get("Settings.NewBttFUnicodeTooltip"));
+        }
+
+        private static void EnsureLoaded()
+        {
+            if (_loaded)
+            {
+                return;
+            }
+
+            string translationPath = Path.Combine(Application.StartupPath, "Translations", "ui-translations.xml");
+            if (!File.Exists(translationPath))
+            {
+                translationPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "Translations", "ui-translations.xml");
+            }
+
+            if (!File.Exists(translationPath))
+            {
+                _translations[DefaultLanguageCode] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                _loaded = true;
+                return;
+            }
+
+            XDocument document = XDocument.Load(translationPath);
+            foreach (XElement languageElement in document.Root.Elements("language"))
+            {
+                XAttribute codeAttribute = languageElement.Attribute("code");
+                if (codeAttribute == null || string.IsNullOrWhiteSpace(codeAttribute.Value))
+                {
+                    continue;
+                }
+
+                Dictionary<string, string> entries = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+                foreach (XElement entryElement in languageElement.Elements("entry"))
+                {
+                    XAttribute keyAttribute = entryElement.Attribute("key");
+                    if (keyAttribute == null || string.IsNullOrWhiteSpace(keyAttribute.Value))
+                    {
+                        continue;
+                    }
+
+                    entries[keyAttribute.Value] = entryElement.Value;
+                }
+
+                _translations[codeAttribute.Value] = entries;
+            }
+
+            if (!_translations.ContainsKey(DefaultLanguageCode))
+            {
+                _translations[DefaultLanguageCode] = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            }
+
+            _loaded = true;
+        }
+    }
+}

--- a/master/Translations/ui-translations.xml
+++ b/master/Translations/ui-translations.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="utf-8"?>
+<translations>
+  <language code="en">
+    <entry key="LanguageName">English</entry>
+    <entry key="Program.MissingConfigTitle">Error</entry>
+    <entry key="Program.MissingConfigMessage">Can't find config.xml!&#10;Please set path for folders, save changes and restart the program!</entry>
+    <entry key="Settings.FormTitle">Settings</entry>
+    <entry key="Settings.AsciiLabel">ASCII</entry>
+    <entry key="Settings.ApplyAndExitButton">Apply and Exit</entry>
+    <entry key="Settings.ApplyButton">Apply</entry>
+    <entry key="Settings.ExitButton">Exit</entry>
+    <entry key="Settings.InputFolderButton">Input Folder</entry>
+    <entry key="Settings.OutputFolderButton">Output Folder</entry>
+    <entry key="Settings.PathsGroup">Auto(De)Packer file paths:</entry>
+    <entry key="Settings.DetectLanguageCheckbox">I don't know ASCII code for my language!</entry>
+    <entry key="Settings.InterfaceLanguageLabel">Interface language:</entry>
+    <entry key="Settings.UnicodeGroup">Unicode mode:</entry>
+    <entry key="Settings.NormalUnicode">Normal Unicode</entry>
+    <entry key="Settings.NonNormalUnicode">Non normal Unicode</entry>
+    <entry key="Settings.NewBttFUnicode">New BttF Unicode</entry>
+    <entry key="Settings.NormalUnicodeTooltip">Recommend to use in new games (From&#10;Minecraft: Story Mode). This option could help&#10;to export/import text files from a new game and&#10;remake fonts with support of your symbols.</entry>
+    <entry key="Settings.NonNormalUnicodeTooltip">Recommend to use in old and some new games (Until&#10;Batman: A Telltale Series). This option could help&#10;to export/import text files from old games and&#10;remake fonts with support of your symbols.</entry>
+    <entry key="Settings.NewBttFUnicodeTooltip">Support all symbols from all modern languages.&#10;Recommend for new version TftB.</entry>
+    <entry key="Settings.RestartMessage">Please restart application to confirm settings.</entry>
+    <entry key="Settings.InvalidPathsMessage">Please set correct paths for input and output folders!</entry>
+  </language>
+
+  <language code="pt-BR">
+    <entry key="LanguageName">Português (Brasil)</entry>
+    <entry key="Program.MissingConfigTitle">Erro</entry>
+    <entry key="Program.MissingConfigMessage">Não foi possível encontrar o arquivo config.xml!&#10;Defina os caminhos das pastas, salve as alterações e reinicie o programa.</entry>
+    <entry key="Settings.FormTitle">Configurações</entry>
+    <entry key="Settings.AsciiLabel">ASCII</entry>
+    <entry key="Settings.ApplyAndExitButton">Aplicar e sair</entry>
+    <entry key="Settings.ApplyButton">Aplicar</entry>
+    <entry key="Settings.ExitButton">Sair</entry>
+    <entry key="Settings.InputFolderButton">Pasta de entrada</entry>
+    <entry key="Settings.OutputFolderButton">Pasta de saída</entry>
+    <entry key="Settings.PathsGroup">Caminhos de arquivos do Auto(De)Packer:</entry>
+    <entry key="Settings.DetectLanguageCheckbox">Não sei o código ASCII do meu idioma!</entry>
+    <entry key="Settings.InterfaceLanguageLabel">Idioma da interface:</entry>
+    <entry key="Settings.UnicodeGroup">Modo Unicode:</entry>
+    <entry key="Settings.NormalUnicode">Unicode normal</entry>
+    <entry key="Settings.NonNormalUnicode">Unicode não normal</entry>
+    <entry key="Settings.NewBttFUnicode">Unicode novo do BttF</entry>
+    <entry key="Settings.NormalUnicodeTooltip">Recomendado para jogos novos (a partir de&#10;Minecraft: Story Mode). Esta opção pode ajudar&#10;a exportar/importar textos e refazer fontes com&#10;suporte aos seus símbolos.</entry>
+    <entry key="Settings.NonNormalUnicodeTooltip">Recomendado para jogos antigos e alguns novos (até&#10;Batman: A Telltale Series). Esta opção pode ajudar&#10;a exportar/importar textos de jogos antigos e&#10;refazer fontes com suporte aos seus símbolos.</entry>
+    <entry key="Settings.NewBttFUnicodeTooltip">Suporta todos os símbolos dos idiomas modernos.&#10;Recomendado para a nova versão de TftB.</entry>
+    <entry key="Settings.RestartMessage">Reinicie o aplicativo para confirmar as configurações.</entry>
+    <entry key="Settings.InvalidPathsMessage">Defina caminhos válidos para as pastas de entrada e saída!</entry>
+  </language>
+
+  <language code="es">
+    <entry key="LanguageName">Español</entry>
+    <entry key="Program.MissingConfigTitle">Error</entry>
+    <entry key="Program.MissingConfigMessage">No se encontró config.xml.&#10;Configura las rutas de carpetas, guarda los cambios y reinicia el programa.</entry>
+    <entry key="Settings.FormTitle">Configuración</entry>
+    <entry key="Settings.AsciiLabel">ASCII</entry>
+    <entry key="Settings.ApplyAndExitButton">Aplicar y salir</entry>
+    <entry key="Settings.ApplyButton">Aplicar</entry>
+    <entry key="Settings.ExitButton">Salir</entry>
+    <entry key="Settings.InputFolderButton">Carpeta de entrada</entry>
+    <entry key="Settings.OutputFolderButton">Carpeta de salida</entry>
+    <entry key="Settings.PathsGroup">Rutas de archivos de Auto(De)Packer:</entry>
+    <entry key="Settings.DetectLanguageCheckbox">¡No conozco el código ASCII de mi idioma!</entry>
+    <entry key="Settings.InterfaceLanguageLabel">Idioma de la interfaz:</entry>
+    <entry key="Settings.UnicodeGroup">Modo Unicode:</entry>
+    <entry key="Settings.NormalUnicode">Unicode normal</entry>
+    <entry key="Settings.NonNormalUnicode">Unicode no normal</entry>
+    <entry key="Settings.NewBttFUnicode">Unicode nuevo de BttF</entry>
+    <entry key="Settings.NormalUnicodeTooltip">Recomendado para juegos nuevos (desde&#10;Minecraft: Story Mode). Esta opción puede ayudar&#10;a exportar/importar textos y rehacer fuentes con&#10;soporte para tus símbolos.</entry>
+    <entry key="Settings.NonNormalUnicodeTooltip">Recomendado para juegos antiguos y algunos nuevos (hasta&#10;Batman: A Telltale Series). Esta opción puede ayudar&#10;a exportar/importar textos de juegos antiguos y&#10;rehacer fuentes con soporte para tus símbolos.</entry>
+    <entry key="Settings.NewBttFUnicodeTooltip">Soporta todos los símbolos de los idiomas modernos.&#10;Recomendado para la nueva versión de TftB.</entry>
+    <entry key="Settings.RestartMessage">Reinicia la aplicación para confirmar la configuración.</entry>
+    <entry key="Settings.InvalidPathsMessage">¡Configura rutas válidas para las carpetas de entrada y salida!</entry>
+  </language>
+
+  <language code="ru">
+    <entry key="LanguageName">Русский</entry>
+    <entry key="Program.MissingConfigTitle">Ошибка</entry>
+    <entry key="Program.MissingConfigMessage">Не удаётся найти файл config.xml.&#10;Укажите пути к папкам, сохраните настройки и перезапустите программу.</entry>
+    <entry key="Settings.FormTitle">Настройки</entry>
+    <entry key="Settings.AsciiLabel">ASCII</entry>
+    <entry key="Settings.ApplyAndExitButton">Применить и выйти</entry>
+    <entry key="Settings.ApplyButton">Применить</entry>
+    <entry key="Settings.ExitButton">Выход</entry>
+    <entry key="Settings.InputFolderButton">Папка входа</entry>
+    <entry key="Settings.OutputFolderButton">Папка выхода</entry>
+    <entry key="Settings.PathsGroup">Пути файлов Auto(De)Packer:</entry>
+    <entry key="Settings.DetectLanguageCheckbox">Я не знаю ASCII-код своего языка!</entry>
+    <entry key="Settings.InterfaceLanguageLabel">Язык интерфейса:</entry>
+    <entry key="Settings.UnicodeGroup">Режим Unicode:</entry>
+    <entry key="Settings.NormalUnicode">Обычный Unicode</entry>
+    <entry key="Settings.NonNormalUnicode">Необычный Unicode</entry>
+    <entry key="Settings.NewBttFUnicode">Новый Unicode BttF</entry>
+    <entry key="Settings.NormalUnicodeTooltip">Рекомендуется для новых игр (начиная с&#10;Minecraft: Story Mode). Эта опция может помочь&#10;экспортировать/импортировать тексты и пересобрать&#10;шрифты с поддержкой ваших символов.</entry>
+    <entry key="Settings.NonNormalUnicodeTooltip">Рекомендуется для старых и некоторых новых игр (до&#10;Batman: A Telltale Series). Эта опция может помочь&#10;экспортировать/импортировать тексты из старых игр и&#10;пересобрать шрифты с поддержкой ваших символов.</entry>
+    <entry key="Settings.NewBttFUnicodeTooltip">Поддерживает все символы современных языков.&#10;Рекомендуется для новой версии TftB.</entry>
+    <entry key="Settings.RestartMessage">Перезапустите приложение, чтобы применить настройки.</entry>
+    <entry key="Settings.InvalidPathsMessage">Укажите корректные пути для входной и выходной папок!</entry>
+  </language>
+</translations>


### PR DESCRIPTION
### Motivation
- Provide a way for the application UI to be shown in multiple languages by moving all settings-form strings to a single external translations file and letting the user pick an interface language. 
- Make it easy to add new languages without changing code by using a centralized XML file for translations.

### Description
- Added a new `UiLocalizer` service (`master/Texts/UiLocalizer.cs`) that loads translations from `Translations/ui-translations.xml`, exposes `Get(...)`, `AvailableLanguages`, and `GetLanguageDisplayName(...)`, and falls back to English when a key/language is missing.
- Persisted the selected interface language in settings by adding a serializable `uiLanguageCode` field to `Settings` and extending the constructor/serialization (`master/Settings.cs`).
- Extended `FormSettings` UI with an `interfaceLanguageComboBox`, wired it to `UiLocalizer.AvailableLanguages`, saved selection to `MainMenu.settings.uiLanguageCode`, and applied localized texts/tooltips to the form (`master/FormSettings.cs`, `master/FormSettings.Designer.cs`).
- Initialize localization at startup (read `uiLanguageCode` from `config.xml` and call `UiLocalizer.Initialize(...)`) and use localized missing-config message (`master/Program.cs`).
- Added initial translations for English, Portuguese (pt-BR), Spanish and Russian in `master/Translations/ui-translations.xml`, and registered the translation file and `UiLocalizer` in the project file (`master/TTG Tools.csproj`).
- Updated default `MainMenu.settings` to include a default UI language code (`"en"`) (`master/MainMenu.cs`).