### PR TITLE
Add PlayStation Vita swizzle/deswizzle support for texture import/export

### DIFF
--- a/master/Graphics/Swizzles/PSVita.cs
+++ b/master/Graphics/Swizzles/PSVita.cs
@@ -1,0 +1,105 @@
+﻿using System;
+
+namespace TTG_Tools.Graphics.Swizzles
+{
+    public static class PSVita
+    {
+        public static byte[] Swizzle(byte[] deswizzledData, int width, int height, int bytesPerPixelSet, int formatBitsPerPixel)
+        {
+            if (bytesPerPixelSet <= 0 || deswizzledData == null || deswizzledData.Length <= bytesPerPixelSet)
+            {
+                return deswizzledData;
+            }
+
+            int calculatedBufferSize = (formatBitsPerPixel * width * height) / 8;
+            byte[] swizzledData = new byte[Math.Max(calculatedBufferSize, bytesPerPixelSet)];
+
+            int maxU = (int)Math.Log(width, 2);
+            int maxV = (int)Math.Log(height, 2);
+
+            for (int j = 0; (j < width * height) && (j * bytesPerPixelSet < deswizzledData.Length); j++)
+            {
+                int u = 0;
+                int v = 0;
+                int origCoord = j;
+
+                for (int k = 0; k < maxU || k < maxV; k++)
+                {
+                    if (k < maxV)
+                    {
+                        v |= (origCoord & 1) << k;
+                        origCoord >>= 1;
+                    }
+
+                    if (k < maxU)
+                    {
+                        u |= (origCoord & 1) << k;
+                        origCoord >>= 1;
+                    }
+                }
+
+                if (u < width && v < height)
+                {
+                    int srcPos = (v * width + u) * bytesPerPixelSet;
+                    int dstPos = j * bytesPerPixelSet;
+
+                    if (srcPos + bytesPerPixelSet <= deswizzledData.Length && dstPos + bytesPerPixelSet <= swizzledData.Length)
+                    {
+                        Array.Copy(deswizzledData, srcPos, swizzledData, dstPos, bytesPerPixelSet);
+                    }
+                }
+            }
+
+            return swizzledData;
+        }
+
+        public static byte[] Unswizzle(byte[] swizzledData, int width, int height, int bytesPerPixelSet, int formatBitsPerPixel)
+        {
+            if (bytesPerPixelSet <= 0 || swizzledData == null || swizzledData.Length <= bytesPerPixelSet)
+            {
+                return swizzledData;
+            }
+
+            int calculatedBufferSize = (formatBitsPerPixel * width * height) / 8;
+            byte[] unswizzledData = new byte[Math.Max(calculatedBufferSize, bytesPerPixelSet)];
+
+            int maxU = (int)Math.Log(width, 2);
+            int maxV = (int)Math.Log(height, 2);
+
+            for (int j = 0; (j < width * height) && (j * bytesPerPixelSet < swizzledData.Length); j++)
+            {
+                int u = 0;
+                int v = 0;
+                int origCoord = j;
+
+                for (int k = 0; k < maxU || k < maxV; k++)
+                {
+                    if (k < maxV)
+                    {
+                        v |= (origCoord & 1) << k;
+                        origCoord >>= 1;
+                    }
+
+                    if (k < maxU)
+                    {
+                        u |= (origCoord & 1) << k;
+                        origCoord >>= 1;
+                    }
+                }
+
+                if (u < width && v < height)
+                {
+                    int srcPos = j * bytesPerPixelSet;
+                    int dstPos = (v * width + u) * bytesPerPixelSet;
+
+                    if (srcPos + bytesPerPixelSet <= swizzledData.Length && dstPos + bytesPerPixelSet <= unswizzledData.Length)
+                    {
+                        Array.Copy(swizzledData, srcPos, unswizzledData, dstPos, bytesPerPixelSet);
+                    }
+                }
+            }
+
+            return unswizzledData;
+        }
+    }
+}

--- a/master/TTG Tools.csproj
+++ b/master/TTG Tools.csproj
@@ -125,6 +125,7 @@
     <Compile Include="Graphics\FontWorker.cs" />
     <Compile Include="Graphics\PVR\pvr.cs" />
     <Compile Include="Graphics\Swizzles\PS4.cs" />
+    <Compile Include="Graphics\Swizzles\PSVita.cs" />
     <Compile Include="Graphics\Swizzles\SwizzleUtilities.cs" />
     <Compile Include="Graphics\Swizzles\Xbox360.cs" />
     <Compile Include="InEngineWords\ClassStructsNames.cs" />


### PR DESCRIPTION
### Motivation
- Add support for PlayStation Vita swizzle/deswizzle so TTG Tools can import/export Vita platform textures (platform `9`) using the same style of swizzle handling already present for PS4/Switch/Xbox360.

### Description
- New `PSVita` swizzler added at `master/Graphics/Swizzles/PSVita.cs` implementing `Swizzle` and `Unswizzle` routines (Morton-like interleaving) with bounds checks and calculated buffer sizing.  
- Integrated Vita handling into the import path: `TextureWorker.ReplaceNewTextures` now calls `PSVita.Swizzle(...)` when `tex.platform.platform == 9` and adjusts per-mip processing.  
- Integrated Vita handling into the export path: `TextureWorker.GetNewTextures` now calls `PSVita.Unswizzle(...)` when `tex.platform.platform == 9` and reconstructs image content if needed.  
- Added helper `GetVitaSwizzleInfo(uint textureFormat, out int bytesPerPixelSet, out int formatBitsPerPixel)` to map texture formats to bytes-per-pixel / bits-per-pixel used by the Vita swizzler.  
- Registered `Graphics\Swizzles\PSVita.cs` in `master/TTG Tools.csproj` so the new file is included in the build.