### PR TITLE
Add PS Vita swizzle option to Font Editor

### DIFF
--- a/master/FontEditor.Designer.cs
+++ b/master/FontEditor.Designer.cs
@@ -90,6 +90,7 @@
             this.rbSwitchSwizzle = new System.Windows.Forms.RadioButton();
             this.rbPS4Swizzle = new System.Windows.Forms.RadioButton();
             this.rbXbox360Swizzle = new System.Windows.Forms.RadioButton();
+            this.rbPSVitaSwizzle = new System.Windows.Forms.RadioButton();
             this.rbNoSwizzle = new System.Windows.Forms.RadioButton();
             this.groupBox1.SuspendLayout();
             this.menuStrip1.SuspendLayout();
@@ -667,10 +668,11 @@
             this.groupBox4.Controls.Add(this.rbSwitchSwizzle);
             this.groupBox4.Controls.Add(this.rbPS4Swizzle);
             this.groupBox4.Controls.Add(this.rbXbox360Swizzle);
+            this.groupBox4.Controls.Add(this.rbPSVitaSwizzle);
             this.groupBox4.Controls.Add(this.rbNoSwizzle);
             this.groupBox4.Location = new System.Drawing.Point(864, 28);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(127, 125);
+            this.groupBox4.Size = new System.Drawing.Size(127, 145);
             this.groupBox4.TabIndex = 30;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Swizzle methods";
@@ -710,6 +712,18 @@
             this.rbXbox360Swizzle.Text = "Xbox 360";
             this.rbXbox360Swizzle.UseVisualStyleBackColor = true;
             this.rbXbox360Swizzle.CheckedChanged += new System.EventHandler(this.rbXbox360Swizzle_CheckedChanged);
+            // 
+            // rbPSVitaSwizzle
+            // 
+            this.rbPSVitaSwizzle.AutoSize = true;
+            this.rbPSVitaSwizzle.Location = new System.Drawing.Point(7, 120);
+            this.rbPSVitaSwizzle.Name = "rbPSVitaSwizzle";
+            this.rbPSVitaSwizzle.Size = new System.Drawing.Size(55, 17);
+            this.rbPSVitaSwizzle.TabIndex = 4;
+            this.rbPSVitaSwizzle.TabStop = true;
+            this.rbPSVitaSwizzle.Text = "PS Vita";
+            this.rbPSVitaSwizzle.UseVisualStyleBackColor = true;
+            this.rbPSVitaSwizzle.CheckedChanged += new System.EventHandler(this.rbPSVitaSwizzle_CheckedChanged);
             // 
             // rbNoSwizzle
             // 
@@ -810,6 +824,7 @@
         private System.Windows.Forms.RadioButton rbSwitchSwizzle;
         private System.Windows.Forms.RadioButton rbPS4Swizzle;
         private System.Windows.Forms.RadioButton rbXbox360Swizzle;
+        private System.Windows.Forms.RadioButton rbPSVitaSwizzle;
         private System.Windows.Forms.RadioButton rbNoSwizzle;
         private System.Windows.Forms.DataGridViewTextBoxColumn Column1;
         private System.Windows.Forms.DataGridViewTextBoxColumn Column2;

--- a/master/FontEditor.cs
+++ b/master/FontEditor.cs
@@ -41,9 +41,11 @@ namespace TTG_Tools
         {
             edited = false; //Tell a program about first launch window form so font is not modified.
             
-            if(MainMenu.settings.swizzlePS4 || MainMenu.settings.swizzleNintendoSwitch)
+            if(MainMenu.settings.swizzlePS4 || MainMenu.settings.swizzleNintendoSwitch || MainMenu.settings.swizzleXbox360 || MainMenu.settings.swizzlePSVita)
             {
                 if (MainMenu.settings.swizzlePS4) rbPS4Swizzle.Checked = true;
+                else if (MainMenu.settings.swizzlePSVita) rbPSVitaSwizzle.Checked = true;
+                else if (MainMenu.settings.swizzleXbox360) rbXbox360Swizzle.Checked = true;
                 else rbSwitchSwizzle.Checked = true;
             }
             else
@@ -151,6 +153,7 @@ namespace TTG_Tools
                 if (MainMenu.settings.swizzleNintendoSwitch) NewTex.platform.platform = 15;
                 if (MainMenu.settings.swizzlePS4) NewTex.platform.platform = 11;
                 if (MainMenu.settings.swizzleXbox360) NewTex.platform.platform = 4;
+                if (MainMenu.settings.swizzlePSVita) NewTex.platform.platform = 9;
             }
             else
             {
@@ -230,6 +233,48 @@ namespace TTG_Tools
                         else
                         {
                             NewTex.Tex.Textures[i].Block = swizzledBlock;
+                        }
+                        break;
+                    case 9:
+                        bool blockCompressed = NewTex.TextureFormat >= 0x40 && NewTex.TextureFormat <= 0x46;
+                        int swizzleWidth = blockCompressed ? Math.Max(1, (w + 3) / 4) : w;
+                        int swizzleHeight = blockCompressed ? Math.Max(1, (h + 3) / 4) : h;
+
+                        int bytesPerPixelSet;
+                        switch (NewTex.TextureFormat)
+                        {
+                            case 0x04:
+                                bytesPerPixelSet = 2;
+                                break;
+                            case 0x10:
+                            case 0x11:
+                                bytesPerPixelSet = 1;
+                                break;
+                            case 0x40:
+                            case 0x43:
+                                bytesPerPixelSet = 8;
+                                break;
+                            case 0x41:
+                            case 0x42:
+                            case 0x44:
+                            case 0x45:
+                            case 0x46:
+                                bytesPerPixelSet = 16;
+                                break;
+                            default:
+                                bytesPerPixelSet = 4;
+                                break;
+                        }
+
+                        int safeBppSet = bytesPerPixelSet;
+                        if (NewTex.Tex.Textures[i].Block.Length > 0 && safeBppSet > NewTex.Tex.Textures[i].Block.Length)
+                        {
+                            safeBppSet = NewTex.Tex.Textures[i].Block.Length;
+                        }
+
+                        if (safeBppSet > 0)
+                        {
+                            NewTex.Tex.Textures[i].Block = PSVita.Swizzle(NewTex.Tex.Textures[i].Block, swizzleWidth, swizzleHeight, safeBppSet, bytesPerPixelSet * 8);
                         }
                         break;
                 }
@@ -2078,6 +2123,7 @@ namespace TTG_Tools
             MainMenu.settings.swizzleXbox360 = false;
             MainMenu.settings.swizzlePS4 = false;
             MainMenu.settings.swizzleNintendoSwitch = false;
+            MainMenu.settings.swizzlePSVita = false;
             Settings.SaveConfig(MainMenu.settings);
         }
 
@@ -2086,6 +2132,7 @@ namespace TTG_Tools
             MainMenu.settings.swizzleXbox360 = false;
             MainMenu.settings.swizzlePS4 = true;
             MainMenu.settings.swizzleNintendoSwitch = false;
+            MainMenu.settings.swizzlePSVita = false;
             Settings.SaveConfig(MainMenu.settings);
         }
 
@@ -2094,6 +2141,7 @@ namespace TTG_Tools
             MainMenu.settings.swizzleXbox360 = false;
             MainMenu.settings.swizzlePS4 = false;
             MainMenu.settings.swizzleNintendoSwitch = true;
+            MainMenu.settings.swizzlePSVita = false;
             Settings.SaveConfig(MainMenu.settings);
         }
 
@@ -2104,6 +2152,19 @@ namespace TTG_Tools
                 MainMenu.settings.swizzleXbox360 = true;
                 MainMenu.settings.swizzlePS4 = false;
                 MainMenu.settings.swizzleNintendoSwitch = false;
+                MainMenu.settings.swizzlePSVita = false;
+                Settings.SaveConfig(MainMenu.settings);
+            }
+        }
+
+        private void rbPSVitaSwizzle_CheckedChanged(object sender, EventArgs e)
+        {
+            if (rbPSVitaSwizzle.Checked)
+            {
+                MainMenu.settings.swizzlePSVita = true;
+                MainMenu.settings.swizzlePS4 = false;
+                MainMenu.settings.swizzleNintendoSwitch = false;
+                MainMenu.settings.swizzleXbox360 = false;
                 Settings.SaveConfig(MainMenu.settings);
             }
         }


### PR DESCRIPTION
### Motivation
- Add support in the Font Editor UI and import flow to choose PS Vita swizzling so users can import DDS/PVR textures swizzled for PS Vita (platform 9).
- Ensure the Font Editor restores and saves the swizzle selection for PS Vita consistently with existing PS4/Switch/Xbox options.

### Description
- Added a new `PS Vita` radio button to the `Swizzle methods` group in the Font Editor designer and expanded the group box height to fit the new control (`master/FontEditor.Designer.cs`).
- Restored saved swizzle selection on load by updating `FontEditor_Load` to consider `swizzlePSVita` and `swizzleXbox360` along with existing platforms (`master/FontEditor.cs`).
- When importing/replacing textures, set `NewTex.platform.platform = 9` if `swizzlePSVita` is selected and added a `case 9` block that computes `swizzleWidth`/`swizzleHeight`, determines `bytesPerPixelSet`, applies bounds to `safeBppSet`, and calls `PSVita.Swizzle(...)` to swizzle the mip data (`master/FontEditor.cs`).
- Updated radio button handlers so selecting any swizzle clears the other platform flags and selecting `PS Vita` sets `MainMenu.settings.swizzlePSVita` (and vice versa), and added the `rbPSVitaSwizzle_CheckedChanged` handler (`master/FontEditor.cs`).