### PR TITLE
Fix PS4 ARGB swizzle dimensions in Auto(De)Packer extraction

### DIFF
--- a/master/Graphics/Swizzles/PS4.cs
+++ b/master/Graphics/Swizzles/PS4.cs
@@ -9,21 +9,24 @@ namespace TTG_Tools.Graphics.Swizzles
 {
     public class PS4
     {
-        public static byte[] Swizzle(byte[] data, int width, int height, int blockSize)
+        public static byte[] Swizzle(byte[] data, int width, int height, int blockSize, int blockWidth = 4, int blockHeight = 4)
         {
-            return DoSwizzle(data, width, height, blockSize, false);
+            return DoSwizzle(data, width, height, blockSize, blockWidth, blockHeight, false);
         }
 
-        public static byte[] Unswizzle(byte[] data, int width, int height, int blockSize)
+        public static byte[] Unswizzle(byte[] data, int width, int height, int blockSize, int blockWidth = 4, int blockHeight = 4)
         {
-            return DoSwizzle(data, width, height, blockSize, true);
+            return DoSwizzle(data, width, height, blockSize, blockWidth, blockHeight, true);
         }
 
-        private static byte[] DoSwizzle(byte[] data, int width, int height, int blockSize, bool unswizzle)
+        private static byte[] DoSwizzle(byte[] data, int width, int height, int blockSize, int blockWidth, int blockHeight, bool unswizzle)
         {
-            // 1. Calcula as dimensões em "Texels" (Blocos de compressão 4x4 pixels)
-            var heightTexels = height / 4;
-            var widthTexels = width / 4;
+            if (blockWidth < 1) blockWidth = 1;
+            if (blockHeight < 1) blockHeight = 1;
+
+            // 1. Calcula as dimensões em "Texels" (pixels para formato linear, blocos 4x4 para formatos BC).
+            var widthTexels = (width + blockWidth - 1) / blockWidth;
+            var heightTexels = (height + blockHeight - 1) / blockHeight;
 
             // 2. Calcula o alinhamento necessário para o PS4 (Blocos de 8x8 Texels = 32x32 Pixels)
             var heightTexelsAligned = (heightTexels + 7) / 8;

--- a/master/Graphics/TextureWorker.cs
+++ b/master/Graphics/TextureWorker.cs
@@ -54,6 +54,39 @@ namespace TTG_Tools.Graphics
             formatBitsPerPixel = bytesPerPixelSet * 8;
         }
 
+        private static void GetPS4SwizzleInfo(uint textureFormat, out int blockSize, out int blockWidth, out int blockHeight)
+        {
+            bool blockCompressed = textureFormat >= 0x40 && textureFormat <= 0x46;
+            blockWidth = blockCompressed ? 4 : 1;
+            blockHeight = blockCompressed ? 4 : 1;
+
+            switch (textureFormat)
+            {
+                case 0x04:
+                    blockSize = 2;
+                    break;
+                case 0x10:
+                case 0x11:
+                    blockSize = 1;
+                    break;
+                case 0x40:
+                case 0x43:
+                    blockSize = 8;
+                    break;
+                case 0x41:
+                case 0x42:
+                case 0x44:
+                case 0x45:
+                case 0x46:
+                case 0x25:
+                    blockSize = 16;
+                    break;
+                default:
+                    blockSize = 4;
+                    break;
+            }
+        }
+
         private static int GetPvrDataOffset(byte[] pvrContent)
         {
             const int pvrHeaderSize = 0x34;
@@ -1718,12 +1751,16 @@ namespace TTG_Tools.Graphics
                             int w = tex.Width;
                             int h = tex.Height;
 
-                            int blockSize = tex.TextureFormat == 0x40 || tex.TextureFormat == 0x43 ? 8 : 16;
+                            int blockSize;
+                            int blockWidth;
+                            int blockHeight;
+                            GetPS4SwizzleInfo(tex.TextureFormat, out blockSize, out blockWidth, out blockHeight);
 
                             for (int i = 0; i < tex.Tex.MipCount; i++)
                             {
-                                if (tex.Tex.Textures[i].Block.Length < blockSize) blockSize = tex.Tex.Textures[i].Block.Length;
-                                tex.Tex.Textures[i].Block = PS4.Swizzle(tex.Tex.Textures[i].Block, w, h, blockSize);
+                                int currentBlockSize = blockSize;
+                                if (tex.Tex.Textures[i].Block.Length < currentBlockSize) currentBlockSize = tex.Tex.Textures[i].Block.Length;
+                                tex.Tex.Textures[i].Block = PS4.Swizzle(tex.Tex.Textures[i].Block, w, h, currentBlockSize, blockWidth, blockHeight);
 
                                 if (w > 1) w /= 2;
                                 if (h > 1) h /= 2;
@@ -2420,12 +2457,16 @@ namespace TTG_Tools.Graphics
                     needsReconstruction = true;
                     int w = tex.Width;
                     int h = tex.Height;
-                    int blockSize = tex.TextureFormat == 0x40 || tex.TextureFormat == 0x43 ? 8 : 16;
+                    int blockSize;
+                    int blockWidth;
+                    int blockHeight;
+                    GetPS4SwizzleInfo(tex.TextureFormat, out blockSize, out blockWidth, out blockHeight);
 
                     for (int i = 0; i < tex.Tex.MipCount; i++)
                     {
-                        if (tex.Tex.Textures[i].Block.Length < blockSize) blockSize = tex.Tex.Textures[i].Block.Length;
-                        tex.Tex.Textures[i].Block = PS4.Unswizzle(tex.Tex.Textures[i].Block, w, h, blockSize);
+                        int currentBlockSize = blockSize;
+                        if (tex.Tex.Textures[i].Block.Length < currentBlockSize) currentBlockSize = tex.Tex.Textures[i].Block.Length;
+                        tex.Tex.Textures[i].Block = PS4.Unswizzle(tex.Tex.Textures[i].Block, w, h, currentBlockSize, blockWidth, blockHeight);
 
                         if (w > 1) w /= 2;
                         if (h > 1) h /= 2;


### PR DESCRIPTION
### Motivation
- Fix truncated/cropped output when extracting PS4 textures (e.g. ARGB 8.8.8.8) from the Auto(De)Packer path that treated all formats as 4x4 block-compressed data.
- Ensure swizzle/unswizzle handles both block-compressed and linear/uncompressed formats correctly by computing texel dimensions per-format.
- Prevent incorrect buffer sizing and copying that caused exported images to be smaller than the original.

### Description
- Extended `PS4.Swizzle`/`PS4.Unswizzle` signatures to accept optional `blockWidth`/`blockHeight` and adjusted `DoSwizzle` to compute `widthTexels`/`heightTexels` from those parameters.
- Added `GetPS4SwizzleInfo` in `master/Graphics/TextureWorker.cs` to map a `textureFormat` to `blockSize`, `blockWidth`, and `blockHeight` so formats like ARGB/IL8/A8 and BCn are handled correctly.
- Updated PS4 import (swizzle) and export (unswizzle) flows in `TextureWorker` to call `GetPS4SwizzleInfo`, clamp per-mip `currentBlockSize`, and pass the per-format block dimensions to the PS4 swizzle routines.