### PR TITLE
Add built-in GitHub release updater

### DIFF
--- a/master/MainMenu.cs
+++ b/master/MainMenu.cs
@@ -281,6 +281,8 @@ namespace TTG_Tools
             reader.Close();
 
             SetProcessWorkingSetSize(System.Diagnostics.Process.GetCurrentProcess().Handle, -1, -1);
+
+            Updater.CheckForUpdatesAsync(this);
         }
 
         private void MainMenu_Resize(object sender, EventArgs e)

--- a/master/TTG Tools.csproj
+++ b/master/TTG Tools.csproj
@@ -82,6 +82,7 @@
     <Reference Include="System.Data.Linq" />
     <Reference Include="System.Drawing" />
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Windows" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
@@ -179,6 +180,7 @@
     <Compile Include="Texts\LangdbWorker.cs" />
     <Compile Include="Texts\ReadText.cs" />
     <Compile Include="Texts\SaveText.cs" />
+    <Compile Include="Updater.cs" />
     <Compile Include="Wrapper\OodleTools.cs" />
     <EmbeddedResource Include="About.resx">
       <DependentUpon>About.cs</DependentUpon>

--- a/master/Updater.cs
+++ b/master/Updater.cs
@@ -1,0 +1,240 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Compression;
+using System.Net;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+
+namespace TTG_Tools
+{
+    internal static class Updater
+    {
+        private const string LatestReleaseApi = "https://api.github.com/repos/zenderovpaulo95/TTG-Tools/releases/latest";
+
+        private class ReleaseInfo
+        {
+            public string Version;
+            public string Name;
+            public string Body;
+            public string DownloadUrl;
+        }
+
+        public static void CheckForUpdatesAsync(Form owner)
+        {
+            Task.Run(() =>
+            {
+                try
+                {
+                    ReleaseInfo release = GetLatestRelease();
+                    if (release == null)
+                        return;
+
+                    Version currentVersion = Assembly.GetExecutingAssembly().GetName().Version;
+                    Version latestVersion;
+
+                    if (!TryParseVersion(release.Version, out latestVersion) || latestVersion <= currentVersion)
+                        return;
+
+                    owner.BeginInvoke((Action)(() => PromptAndUpdate(owner, release, currentVersion, latestVersion)));
+                }
+                catch
+                {
+                    // Silent fail: update checks should never break the main app flow.
+                }
+            });
+        }
+
+        private static void PromptAndUpdate(Form owner, ReleaseInfo release, Version currentVersion, Version latestVersion)
+        {
+            string message = string.Format(
+                "A new TTG Tools version is available.\n\nCurrent version: {0}\nLatest version: {1}\n\nDo you want to download and install it now?",
+                currentVersion,
+                latestVersion);
+
+            DialogResult result = MessageBox.Show(owner, message, "Update available", MessageBoxButtons.YesNo, MessageBoxIcon.Information);
+            if (result != DialogResult.Yes)
+                return;
+
+            try
+            {
+                DownloadAndInstallUpdate(owner, release);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show(owner, "Update failed:\n" + ex.Message, "Updater", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
+        }
+
+        private static void DownloadAndInstallUpdate(Form owner, ReleaseInfo release)
+        {
+            if (string.IsNullOrEmpty(release.DownloadUrl))
+            {
+                throw new InvalidOperationException("No downloadable asset was found in the latest GitHub release.");
+            }
+
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
+            string extension = Path.GetExtension(release.DownloadUrl).ToLowerInvariant();
+            string downloadFile = Path.Combine(Path.GetTempPath(), "TTGToolsUpdate_" + Guid.NewGuid().ToString("N") + extension);
+
+            using (WebClient client = new WebClient())
+            {
+                client.Headers[HttpRequestHeader.UserAgent] = "TTG-Tools-Updater";
+                client.DownloadFile(release.DownloadUrl, downloadFile);
+            }
+
+            if (extension == ".exe")
+            {
+                Process.Start(downloadFile);
+                MessageBox.Show(owner, "The updater executable has been launched.\nTTG Tools will close now.", "Updater", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                Application.Exit();
+                return;
+            }
+
+            if (extension != ".zip")
+            {
+                throw new InvalidOperationException("Unsupported update package format: " + extension);
+            }
+
+            string extractDir = Path.Combine(Path.GetTempPath(), "TTGToolsExtract_" + Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(extractDir);
+            ZipFile.ExtractToDirectory(downloadFile, extractDir);
+
+            string appPath = Application.ExecutablePath;
+            string appDir = Path.GetDirectoryName(appPath);
+            string appExeName = Path.GetFileName(appPath);
+
+            string extractedExePath = Path.Combine(extractDir, appExeName);
+            if (!File.Exists(extractedExePath))
+            {
+                string[] exes = Directory.GetFiles(extractDir, "*.exe", SearchOption.AllDirectories);
+                if (exes.Length > 0)
+                {
+                    extractedExePath = exes[0];
+                }
+                else
+                {
+                    throw new InvalidOperationException("Downloaded package does not contain an executable file.");
+                }
+            }
+
+            int currentPid = Process.GetCurrentProcess().Id;
+            string scriptPath = Path.Combine(Path.GetTempPath(), "TTGToolsUpdater_" + Guid.NewGuid().ToString("N") + ".cmd");
+            string script = string.Join("\r\n", new[]
+            {
+                "@echo off",
+                "setlocal",
+                ":waitloop",
+                string.Format("tasklist /FI \"PID eq {0}\" | find \"{0}\" >nul", currentPid),
+                "if not errorlevel 1 (",
+                "  timeout /t 1 /nobreak >nul",
+                "  goto waitloop",
+                ")",
+                string.Format("xcopy \"{0}\\*\" \"{1}\\\" /E /Y /I >nul", extractDir, appDir),
+                string.Format("start \"\" \"{0}\"", Path.Combine(appDir, Path.GetFileName(extractedExePath))),
+                string.Format("rmdir /S /Q \"{0}\"", extractDir),
+                string.Format("del /Q \"{0}\"", downloadFile),
+                "del /Q \"%~f0\""
+            });
+
+            File.WriteAllText(scriptPath, script);
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "cmd.exe",
+                Arguments = "/C \"" + scriptPath + "\"",
+                CreateNoWindow = true,
+                UseShellExecute = false
+            });
+
+            MessageBox.Show(owner, "Update downloaded. TTG Tools will close to finish updating and then restart automatically.", "Updater", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            Application.Exit();
+        }
+
+        private static ReleaseInfo GetLatestRelease()
+        {
+            ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
+
+            string json;
+            using (WebClient client = new WebClient())
+            {
+                client.Headers[HttpRequestHeader.UserAgent] = "TTG-Tools-Updater";
+                json = client.DownloadString(LatestReleaseApi);
+            }
+
+            if (string.IsNullOrEmpty(json))
+                return null;
+
+            ReleaseInfo release = new ReleaseInfo
+            {
+                Version = ReadJsonString(json, "tag_name"),
+                Name = ReadJsonString(json, "name"),
+                Body = ReadJsonString(json, "body"),
+                DownloadUrl = SelectDownloadUrl(json)
+            };
+
+            if (string.IsNullOrEmpty(release.Version))
+                return null;
+
+            return release;
+        }
+
+        private static string SelectDownloadUrl(string json)
+        {
+            MatchCollection matches = Regex.Matches(json, "\\\"browser_download_url\\\"\\s*:\\s*\\\"([^\\\"]+)\\\"");
+            if (matches.Count == 0)
+                return null;
+
+            List<string> urls = new List<string>();
+            foreach (Match match in matches)
+            {
+                urls.Add(JsonUnescape(match.Groups[1].Value));
+            }
+
+            string zip = urls.Find(u => u.EndsWith(".zip", StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrEmpty(zip))
+                return zip;
+
+            string exe = urls.Find(u => u.EndsWith(".exe", StringComparison.OrdinalIgnoreCase));
+            if (!string.IsNullOrEmpty(exe))
+                return exe;
+
+            return urls[0];
+        }
+
+        private static string ReadJsonString(string json, string key)
+        {
+            Match match = Regex.Match(json, "\\\"" + Regex.Escape(key) + "\\\"\\s*:\\s*\\\"([^\\\"]*)\\\"");
+            return match.Success ? JsonUnescape(match.Groups[1].Value) : string.Empty;
+        }
+
+        private static string JsonUnescape(string value)
+        {
+            if (string.IsNullOrEmpty(value))
+                return value;
+
+            string normalized = value.Replace("\\/", "/");
+            return Regex.Unescape(normalized);
+        }
+
+        private static bool TryParseVersion(string rawVersion, out Version version)
+        {
+            version = null;
+            if (string.IsNullOrEmpty(rawVersion))
+                return false;
+
+            string normalized = rawVersion.Trim();
+            if (normalized.StartsWith("v", StringComparison.OrdinalIgnoreCase))
+                normalized = normalized.Substring(1);
+
+            int suffixStart = normalized.IndexOf('-');
+            if (suffixStart >= 0)
+                normalized = normalized.Substring(0, suffixStart);
+
+            return Version.TryParse(normalized, out version);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide an integrated updater so users can be notified of new GitHub releases and download/install updates without manual intervention.

### Description
- Added `master/Updater.cs`, an internal `Updater` that polls the GitHub Releases API, compares the release `tag_name` to the running assembly version, and prompts the user when a newer version is available; it prefers `.zip` assets and falls back to `.exe`.
- Implemented download-and-install flow in `Updater`: downloads the asset, extracts `.zip` packages, writes a temporary updater script that waits for the app to exit, copies files into the application folder and relaunches, or launches a downloaded `.exe` updater directly.
- Wired the updater into startup by calling `Updater.CheckForUpdatesAsync(this)` from `MainMenu_Load` so the check runs in background on app start.
- Updated project file to add the `System.IO.Compression.FileSystem` reference and include `Updater.cs` in the build.

### Testing
- Attempted to build with `msbuild 'TTG Tools.sln' /p:Configuration=Release`, which failed because `msbuild` is not available in the environment (failed).
- Attempted to build with `dotnet build 'TTG Tools.sln' -c Release`, which failed because `dotnet` is not available in the environment (failed).
- Performed automated static validations by inspecting the modified files with `git diff`, `rg`, and file listings to confirm `Updater.cs` was added and `MainMenu.cs` and the project file were updated as expected (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698eb16a821883319ab61e331991bab4)