### PR TITLE
Fix PS Vita swizzle for non-power-of-two textures

### DIFF
--- a/master/Graphics/Swizzles/PSVita.cs
+++ b/master/Graphics/Swizzles/PSVita.cs
@@ -4,6 +4,34 @@ namespace TTG_Tools.Graphics.Swizzles
 {
     public static class PSVita
     {
+        private static int NextPowerOfTwo(int value)
+        {
+            if (value <= 1)
+            {
+                return 1;
+            }
+
+            int power = 1;
+            while (power < value)
+            {
+                power <<= 1;
+            }
+
+            return power;
+        }
+
+        private static int IntegerLog2(int value)
+        {
+            int log = 0;
+            while (value > 1)
+            {
+                value >>= 1;
+                log++;
+            }
+
+            return log;
+        }
+
         public static byte[] Swizzle(byte[] deswizzledData, int width, int height, int bytesPerPixelSet, int formatBitsPerPixel)
         {
             if (bytesPerPixelSet <= 0 || deswizzledData == null || deswizzledData.Length <= bytesPerPixelSet)
@@ -14,10 +42,13 @@ namespace TTG_Tools.Graphics.Swizzles
             int calculatedBufferSize = (formatBitsPerPixel * width * height) / 8;
             byte[] swizzledData = new byte[Math.Max(calculatedBufferSize, bytesPerPixelSet)];
 
-            int maxU = (int)Math.Log(width, 2);
-            int maxV = (int)Math.Log(height, 2);
+            int paddedWidth = NextPowerOfTwo(width);
+            int paddedHeight = NextPowerOfTwo(height);
+            int maxU = IntegerLog2(paddedWidth);
+            int maxV = IntegerLog2(paddedHeight);
+            int maxSwizzledTexels = Math.Min((swizzledData.Length / bytesPerPixelSet), paddedWidth * paddedHeight);
 
-            for (int j = 0; (j < width * height) && (j * bytesPerPixelSet < deswizzledData.Length); j++)
+            for (int j = 0; j < maxSwizzledTexels; j++)
             {
                 int u = 0;
                 int v = 0;
@@ -63,10 +94,13 @@ namespace TTG_Tools.Graphics.Swizzles
             int calculatedBufferSize = (formatBitsPerPixel * width * height) / 8;
             byte[] unswizzledData = new byte[Math.Max(calculatedBufferSize, bytesPerPixelSet)];
 
-            int maxU = (int)Math.Log(width, 2);
-            int maxV = (int)Math.Log(height, 2);
+            int paddedWidth = NextPowerOfTwo(width);
+            int paddedHeight = NextPowerOfTwo(height);
+            int maxU = IntegerLog2(paddedWidth);
+            int maxV = IntegerLog2(paddedHeight);
+            int maxSwizzledTexels = Math.Min((swizzledData.Length / bytesPerPixelSet), paddedWidth * paddedHeight);
 
-            for (int j = 0; (j < width * height) && (j * bytesPerPixelSet < swizzledData.Length); j++)
+            for (int j = 0; j < maxSwizzledTexels; j++)
             {
                 int u = 0;
                 int v = 0;

--- a/master/Graphics/Swizzles/PSVita.cs
+++ b/master/Graphics/Swizzles/PSVita.cs
@@ -39,11 +39,13 @@ namespace TTG_Tools.Graphics.Swizzles
                 return deswizzledData;
             }
 
-            int calculatedBufferSize = (formatBitsPerPixel * width * height) / 8;
-            byte[] swizzledData = new byte[Math.Max(calculatedBufferSize, bytesPerPixelSet)];
-
             int paddedWidth = NextPowerOfTwo(width);
             int paddedHeight = NextPowerOfTwo(height);
+
+            int calculatedBufferSize = (formatBitsPerPixel * width * height) / 8;
+            int paddedBufferSize = (formatBitsPerPixel * paddedWidth * paddedHeight) / 8;
+            byte[] swizzledData = new byte[Math.Max(Math.Max(calculatedBufferSize, paddedBufferSize), bytesPerPixelSet)];
+
             int maxU = IntegerLog2(paddedWidth);
             int maxV = IntegerLog2(paddedHeight);
             int maxSwizzledTexels = Math.Min((swizzledData.Length / bytesPerPixelSet), paddedWidth * paddedHeight);


### PR DESCRIPTION
### Motivation
- Fonts extracted from The Walking Dead Season 1 (PS Vita) with non-power-of-two dimensions (example: `512x792`) were deswizzled incorrectly, producing scrambled/mixed blocks and misplaced glyph regions.
- The previous Morton addressing used `Math.Log` on the raw width/height and iterated only up to `width*height`, which caused coordinate collisions for NPOT textures and left many texels unmapped.

### Description
- Added integer helpers `NextPowerOfTwo` and `IntegerLog2` and replaced the floating-point `Math.Log` usage with these safer integer operations.
- Compute `paddedWidth`/`paddedHeight` (next power-of-two) for Morton addressing and derive `maxU`/`maxV` from them.
- Introduced `maxSwizzledTexels = Math.Min((swizzledData.Length / bytesPerPixelSet), paddedWidth * paddedHeight)` and changed the swizzle/unswizzle loops to iterate to this bound to avoid collisions and out-of-range mapping.
- Applied the same padded-coordinate logic to both `Swizzle` and `Unswizzle` in `master/Graphics/Swizzles/PSVita.cs` so extraction and reinsertion behave consistently for NPOT textures.