### PR TITLE
Fix old-format FNT import handling for Unicode glyph ids

### DIFF
--- a/master/FontEditor.cs
+++ b/master/FontEditor.cs
@@ -2078,19 +2078,19 @@ namespace TTG_Tools
 
                                             if (isUnicodeFnt)
                                             {
-                                                if(tmpChar == 126)
+                                                byte[] tmpCharBytes = BitConverter.GetBytes(tmpChar);
+                                                byte[] converted = Encoding.Convert(Encoding.Unicode, Encoding.GetEncoding(MainMenu.settings.ASCII_N), tmpCharBytes);
+                                                if (converted.Length > 0)
                                                 {
-                                                    int puase = 1;
+                                                    tmpChar = converted[0];
                                                 }
-                                                byte[] tmp_ch = BitConverter.GetBytes(Convert.ToUInt32(splitted[k + 1]));
-                                                tmp_ch = Encoding.Convert(Encoding.Unicode, Encoding.GetEncoding(MainMenu.settings.ASCII_N), tmp_ch);
-                                                tmpChar = BitConverter.ToUInt16(tmp_ch, 0);
                                             }
                                         }
 
-                                        for(int t = 0; t < font.glyph.CharCount; t++)
+                                        ch = -1;
+                                        for (int t = 0; t < font.glyph.CharCount; t++)
                                         {
-                                            if(Convert.ToUInt32(dataGridViewWithCoord[0, t].Value) == tmpChar)
+                                            if (Convert.ToUInt32(dataGridViewWithCoord[0, t].Value) == tmpChar)
                                             {
                                                 ch = t;
                                                 break;
@@ -2100,39 +2100,45 @@ namespace TTG_Tools
                                         break;
 
                                     case "x":
-                                        font.glyph.chars[ch].XStart = Convert.ToSingle(splitted[k + 1]);
+                                        if (ch >= 0) font.glyph.chars[ch].XStart = Convert.ToSingle(splitted[k + 1]);
                                         break;
 
                                     case "y":
-                                        font.glyph.chars[ch].YStart = Convert.ToSingle(splitted[k + 1]);
+                                        if (ch >= 0) font.glyph.chars[ch].YStart = Convert.ToSingle(splitted[k + 1]);
                                         break;
 
                                     case "width":
-                                        if (font.hasScaleValue)
+                                        if (ch >= 0)
                                         {
-                                            font.glyph.chars[ch].CharWidth = Convert.ToSingle(splitted[k + 1]);
-                                            font.glyph.chars[ch].XEnd = font.glyph.chars[ch].XStart + font.glyph.chars[ch].CharWidth;
-                                        }
-                                        else
-                                        {
-                                            font.glyph.chars[ch].XEnd = font.glyph.chars[ch].XStart + Convert.ToSingle(splitted[k + 1]);
+                                            if (font.hasScaleValue)
+                                            {
+                                                font.glyph.chars[ch].CharWidth = Convert.ToSingle(splitted[k + 1]);
+                                                font.glyph.chars[ch].XEnd = font.glyph.chars[ch].XStart + font.glyph.chars[ch].CharWidth;
+                                            }
+                                            else
+                                            {
+                                                font.glyph.chars[ch].XEnd = font.glyph.chars[ch].XStart + Convert.ToSingle(splitted[k + 1]);
+                                            }
                                         }
                                         break;
 
                                     case "height":
-                                        if (font.hasScaleValue)
+                                        if (ch >= 0)
                                         {
-                                            font.glyph.chars[ch].CharHeight = Convert.ToSingle(splitted[k + 1]);
-                                            font.glyph.chars[ch].YEnd = font.glyph.chars[ch].YStart + font.glyph.chars[ch].CharHeight;
-                                        }
-                                        else
-                                        {
-                                            font.glyph.chars[ch].YEnd = font.glyph.chars[ch].YStart + Convert.ToSingle(splitted[k + 1]);
+                                            if (font.hasScaleValue)
+                                            {
+                                                font.glyph.chars[ch].CharHeight = Convert.ToSingle(splitted[k + 1]);
+                                                font.glyph.chars[ch].YEnd = font.glyph.chars[ch].YStart + font.glyph.chars[ch].CharHeight;
+                                            }
+                                            else
+                                            {
+                                                font.glyph.chars[ch].YEnd = font.glyph.chars[ch].YStart + Convert.ToSingle(splitted[k + 1]);
+                                            }
                                         }
                                         break;
 
                                     case "page":
-                                        font.glyph.chars[ch].TexNum = Convert.ToInt32(splitted[k + 1]);
+                                        if (ch >= 0) font.glyph.chars[ch].TexNum = Convert.ToInt32(splitted[k + 1]);
                                         break;
                                 }
                             }


### PR DESCRIPTION
### Motivation
- Users reported certain accented characters became invisible in-game on PS Vita despite correct texture and FNT coordinates, indicating wrong glyph mapping during import of older `.fnt` files. 
- Investigation showed the old-format import path contained a fragile Unicode-to-single-byte conversion and a leftover debug branch, and it reused the previous glyph index when a `char id` did not map, allowing accidental overwrites.

### Description
- Updated `master/FontEditor.cs` to perform a safer conversion of imported Unicode `char id` values into the configured single-byte game encoding using `Encoding.Convert` applied to the `tmpChar` bytes and using the converted byte instead of the previous debug/unsafe code path. 
- Reset the glyph lookup index with `ch = -1` for each `char id` entry to avoid applying coordinates when no matching glyph is found. 
- Guarded assignments to glyph fields (`x`, `y`, `width`, `height`, `page`) so they are only applied when a valid glyph index is present (`if (ch >= 0) ...`). 
- Changes are contained in `master/FontEditor.cs` (old-format `.fnt` import section), removing the debug leftover and preventing unintended edits of the previous glyph.