### PR TITLE
Fix PS Vita font texture mip sizes after swizzle padding

### DIFF
--- a/master/FontEditor.cs
+++ b/master/FontEditor.cs
@@ -233,6 +233,7 @@ namespace TTG_Tools
             {
                 NewTex.Tex.Textures[i].CurrentMip = i;
                 Methods.getSizeAndKratnost(w, h, (int)NewTex.TextureFormat, ref NewTex.Tex.Textures[i].MipSize, ref NewTex.Tex.Textures[i].BlockSize);
+                int sourceMipSize = NewTex.Tex.Textures[i].MipSize;
 
                 NewTex.Tex.Textures[i].Block = new byte[NewTex.Tex.Textures[i].MipSize];
 
@@ -329,12 +330,19 @@ namespace TTG_Tools
                         if (safeBppSet > 0)
                         {
                             NewTex.Tex.Textures[i].Block = PSVita.Swizzle(NewTex.Tex.Textures[i].Block, swizzleWidth, swizzleHeight, safeBppSet, bytesPerPixelSet * 8);
+
+                            // PS Vita NPOT textures can expand after swizzle padding (power-of-two backing).
+                            // Keep mip/header sizes in sync to avoid truncating the bottom part of glyph atlas.
+                            if (NewTex.Tex.Textures[i].Block != null)
+                            {
+                                NewTex.Tex.Textures[i].MipSize = NewTex.Tex.Textures[i].Block.Length;
+                            }
                         }
                         break;
                 }
 
 
-                pos += NewTex.Tex.Textures[i].MipSize;
+                pos += sourceMipSize;
                 NewTex.Tex.TexSize += (uint)NewTex.Tex.Textures[i].MipSize;
 
                 if (NewTex.SomeValue >= 5) NewTex.Tex.Textures[i].SubTexNum = 0;

--- a/master/FontEditor.cs
+++ b/master/FontEditor.cs
@@ -1815,11 +1815,15 @@ namespace TTG_Tools
                     var yEn = font.glyph.charsNew[i].YEnd / font.NewTex[font.glyph.charsNew[i].TexNum].Height;
                     bw.Write(yEn);
 
+                    float xOffset = rbNoKerning.Checked ? 0 : font.glyph.charsNew[i].XOffset;
+                    float yOffset = rbNoKerning.Checked ? 0 : font.glyph.charsNew[i].YOffset;
+                    float xAdvance = rbNoKerning.Checked ? font.glyph.charsNew[i].CharWidth : font.glyph.charsNew[i].XAdvance;
+
                     bw.Write(font.glyph.charsNew[i].CharWidth);
                     bw.Write(font.glyph.charsNew[i].CharHeight);
-                    bw.Write(font.glyph.charsNew[i].XOffset);
-                    bw.Write(font.glyph.charsNew[i].YOffset);
-                    bw.Write(font.glyph.charsNew[i].XAdvance);
+                    bw.Write(xOffset);
+                    bw.Write(yOffset);
+                    bw.Write(xAdvance);
 
                     font.headerSize += (4 * 12);
                 }
@@ -2361,9 +2365,13 @@ namespace TTG_Tools
                     for (int i = 0; i < font.glyph.CharCount; i++)
                     {
                         info = "char id=" + font.glyph.charsNew[i].charId + " x=" + font.glyph.charsNew[i].XStart + " y=" + font.glyph.charsNew[i].YStart;
+                        float xOffset = rbNoKerning.Checked ? 0 : font.glyph.charsNew[i].XOffset;
+                        float yOffset = rbNoKerning.Checked ? 0 : font.glyph.charsNew[i].YOffset;
+                        float xAdvance = rbNoKerning.Checked ? font.glyph.charsNew[i].CharWidth : font.glyph.charsNew[i].XAdvance;
+
                         info += " width=" + font.glyph.charsNew[i].CharWidth + " height=" + font.glyph.charsNew[i].CharHeight;
-                        info += " xoffset=" + font.glyph.charsNew[i].XOffset + " yoffset=" + font.glyph.charsNew[i].YOffset + " xadvance=";
-                        info += font.glyph.charsNew[i].XAdvance + " page=" + font.glyph.charsNew[i].TexNum + " chnl=" + font.glyph.charsNew[i].Channel + "\r\n";
+                        info += " xoffset=" + xOffset + " yoffset=" + yOffset + " xadvance=";
+                        info += xAdvance + " page=" + font.glyph.charsNew[i].TexNum + " chnl=" + font.glyph.charsNew[i].Channel + "\r\n";
 
                         sw.Write(info);
                     }
@@ -2584,6 +2592,13 @@ namespace TTG_Tools
                                         font.glyph.charsNew[ch].Channel = Convert.ToInt32(splitted[k + 1]);
                                         break;
                                 }
+                            }
+
+                            if (rbNoKerning.Checked)
+                            {
+                                font.glyph.charsNew[ch].XOffset = 0;
+                                font.glyph.charsNew[ch].YOffset = 0;
+                                font.glyph.charsNew[ch].XAdvance = font.glyph.charsNew[ch].CharWidth;
                             }
                         }
                     }


### PR DESCRIPTION
Fix PS Vita font texture mip sizes after swizzle padding

Respect Without Kerning option in font import/export and save