### PR TITLE
Fix PS Vita NPOT swizzle ordering and preserve original MipSize on reinsertion

### DIFF
--- a/master/FontEditor.cs
+++ b/master/FontEditor.cs
@@ -328,7 +328,19 @@ namespace TTG_Tools
 
                         if (safeBppSet > 0)
                         {
-                            NewTex.Tex.Textures[i].Block = PSVita.Swizzle(NewTex.Tex.Textures[i].Block, swizzleWidth, swizzleHeight, safeBppSet, bytesPerPixelSet * 8);
+                            byte[] swizzledBlock = PSVita.Swizzle(NewTex.Tex.Textures[i].Block, swizzleWidth, swizzleHeight, safeBppSet, bytesPerPixelSet * 8);
+                            int originalMipSize = NewTex.Tex.Textures[i].MipSize;
+
+                            if (swizzledBlock.Length != originalMipSize)
+                            {
+                                byte[] normalizedBlock = new byte[originalMipSize];
+                                Array.Copy(swizzledBlock, 0, normalizedBlock, 0, Math.Min(swizzledBlock.Length, originalMipSize));
+                                NewTex.Tex.Textures[i].Block = normalizedBlock;
+                            }
+                            else
+                            {
+                                NewTex.Tex.Textures[i].Block = swizzledBlock;
+                            }
                         }
                         break;
                 }


### PR DESCRIPTION
### Motivation
- NPOT PS Vita textures could lose valid pixels (e.g., bottom-right corner) when swizzled data was stored using padded Morton indices and then truncated to the original mip payload size.
- Some Vita titles rely on the original `MipSize`/offsets stored in the file header, so expanding header mip sizes to padded swizzle sizes caused corrupted textures on reinsertion.

### Description
- Changed `master/Graphics/Swizzles/PSVita.cs` to use a compact valid-texel ordering in `Swizzle(...)` that iterates the padded Morton space but sequentially writes only in-bounds texels (`swizzledIndex`) so no valid pixels are omitted, and updated `Unswizzle(...)` to mirror that ordering when reconstructing the image.
- Updated `master/Graphics/TextureWorker.cs` to stop expanding the PS Vita header `MipSize` to padded swizzle sizes and to normalize swizzled output back to the original `MipSize` by truncating or zero-padding the swizzled block before storing it.
- Applied the same swizzle-output normalization to `master/FontEditor.cs` so DDS/font import uses identical behavior when producing swizzled Vita blocks.
- All changes preserve original header `MipSize` semantics while ensuring the swizzled payload contains every valid texel for NPOT textures.