### PR TITLE
Add PROP Editor UI and worker for in-app .prop editing

### DIFF
--- a/master/MainMenu.Designer.cs
+++ b/master/MainMenu.Designer.cs
@@ -39,6 +39,7 @@
             this.settingsBtn = new System.Windows.Forms.Button();
             this.archivePackerBtn = new System.Windows.Forms.Button();
             this.arcUnpackerBtn = new System.Windows.Forms.Button();
+            this.propEditorBtn = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // autopackerBtn
@@ -119,11 +120,22 @@
             this.arcUnpackerBtn.UseVisualStyleBackColor = true;
             this.arcUnpackerBtn.Click += new System.EventHandler(this.arcUnpackerBtn_Click);
             // 
+            // propEditorBtn
+            // 
+            this.propEditorBtn.Location = new System.Drawing.Point(127, 108);
+            this.propEditorBtn.Name = "propEditorBtn";
+            this.propEditorBtn.Size = new System.Drawing.Size(112, 23);
+            this.propEditorBtn.TabIndex = 14;
+            this.propEditorBtn.Text = "Prop Editor";
+            this.propEditorBtn.UseVisualStyleBackColor = true;
+            this.propEditorBtn.Click += new System.EventHandler(this.propEditorBtn_Click);
+            // 
             // MainMenu
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(370, 191);
+            this.Controls.Add(this.propEditorBtn);
             this.Controls.Add(this.arcUnpackerBtn);
             this.Controls.Add(this.archivePackerBtn);
             this.Controls.Add(this.settingsBtn);
@@ -153,5 +165,6 @@
         private System.Windows.Forms.Button settingsBtn;
         private System.Windows.Forms.Button archivePackerBtn;
         private System.Windows.Forms.Button arcUnpackerBtn;
+        private System.Windows.Forms.Button propEditorBtn;
     }
 }

--- a/master/MainMenu.cs
+++ b/master/MainMenu.cs
@@ -352,5 +352,14 @@ namespace TTG_Tools
                 arcUnpackerForm.Show();
             }
         }
+
+        private void propEditorBtn_Click(object sender, EventArgs e)
+        {
+            if (Application.OpenForms.OfType<PropEditor>().Count() == 0)
+            {
+                Form propEditorForm = new PropEditor();
+                propEditorForm.Show();
+            }
+        }
     }
-}
+}

--- a/master/PropEditor.cs
+++ b/master/PropEditor.cs
@@ -1,0 +1,209 @@
+using System;
+using System.ComponentModel;
+using System.Drawing;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using TTG_Tools.Texts;
+
+namespace TTG_Tools
+{
+    public class PropEditor : Form
+    {
+        private readonly BindingList<PropEditorEntry> entries = new BindingList<PropEditorEntry>();
+        private PropEditorDocument document;
+
+        private TextBox filePathTextBox;
+        private DataGridView grid;
+        private TextBox findTextBox;
+        private TextBox replaceTextBox;
+        private Label metaLabel;
+
+        public PropEditor()
+        {
+            InitializeUi();
+        }
+
+        private void InitializeUi()
+        {
+            Text = "PROP Editor";
+            Width = 920;
+            Height = 620;
+            StartPosition = FormStartPosition.CenterScreen;
+
+            Panel topPanel = new Panel { Dock = DockStyle.Top, Height = 72 };
+            Controls.Add(topPanel);
+
+            Button openButton = new Button { Text = "Open .prop", Left = 10, Top = 10, Width = 100 };
+            openButton.Click += OpenButton_Click;
+            topPanel.Controls.Add(openButton);
+
+            Button saveButton = new Button { Text = "Save As", Left = 120, Top = 10, Width = 100 };
+            saveButton.Click += SaveButton_Click;
+            topPanel.Controls.Add(saveButton);
+
+            Button reloadButton = new Button { Text = "Reload", Left = 230, Top = 10, Width = 100 };
+            reloadButton.Click += ReloadButton_Click;
+            topPanel.Controls.Add(reloadButton);
+
+            filePathTextBox = new TextBox { Left = 10, Top = 41, Width = 560, ReadOnly = true };
+            topPanel.Controls.Add(filePathTextBox);
+
+            metaLabel = new Label { Left = 580, Top = 44, Width = 320, Text = "No file loaded" };
+            topPanel.Controls.Add(metaLabel);
+
+            Panel findPanel = new Panel { Dock = DockStyle.Top, Height = 42 };
+            Controls.Add(findPanel);
+
+            findPanel.Controls.Add(new Label { Left = 10, Top = 12, Width = 36, Text = "Find:" });
+            findTextBox = new TextBox { Left = 50, Top = 9, Width = 210 };
+            findPanel.Controls.Add(findTextBox);
+
+            findPanel.Controls.Add(new Label { Left = 270, Top = 12, Width = 55, Text = "Replace:" });
+            replaceTextBox = new TextBox { Left = 330, Top = 9, Width = 210 };
+            findPanel.Controls.Add(replaceTextBox);
+
+            Button replaceAllButton = new Button { Left = 550, Top = 8, Width = 110, Text = "Replace All" };
+            replaceAllButton.Click += ReplaceAllButton_Click;
+            findPanel.Controls.Add(replaceAllButton);
+
+            Button addLineButton = new Button { Left = 670, Top = 8, Width = 110, Text = "Add Empty" };
+            addLineButton.Click += AddLineButton_Click;
+            findPanel.Controls.Add(addLineButton);
+
+            Button removeLineButton = new Button { Left = 790, Top = 8, Width = 110, Text = "Remove Row" };
+            removeLineButton.Click += RemoveLineButton_Click;
+            findPanel.Controls.Add(removeLineButton);
+
+            grid = new DataGridView
+            {
+                Dock = DockStyle.Fill,
+                AutoGenerateColumns = false,
+                AllowUserToAddRows = false,
+                SelectionMode = DataGridViewSelectionMode.FullRowSelect,
+                MultiSelect = false,
+                DataSource = entries
+            };
+
+            grid.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = "Index",
+                HeaderText = "#",
+                Width = 60,
+                ReadOnly = true
+            });
+
+            grid.Columns.Add(new DataGridViewTextBoxColumn
+            {
+                DataPropertyName = "Value",
+                HeaderText = "Text",
+                AutoSizeMode = DataGridViewAutoSizeColumnMode.Fill
+            });
+
+            Controls.Add(grid);
+        }
+
+        private void OpenButton_Click(object sender, EventArgs e)
+        {
+            OpenFileDialog ofd = new OpenFileDialog();
+            ofd.Filter = "PROP files (*.prop)|*.prop|All files (*.*)|*.*";
+            if (ofd.ShowDialog() != DialogResult.OK) return;
+
+            LoadProp(ofd.FileName);
+        }
+
+        private void ReloadButton_Click(object sender, EventArgs e)
+        {
+            if (document == null || string.IsNullOrEmpty(document.FilePath)) return;
+            LoadProp(document.FilePath);
+        }
+
+        private void LoadProp(string filePath)
+        {
+            try
+            {
+                document = PropEditorWorker.Load(filePath);
+                entries.Clear();
+                foreach (PropEditorEntry entry in document.Entries)
+                {
+                    entries.Add(new PropEditorEntry { Index = entry.Index, Value = entry.Value });
+                }
+
+                filePathTextBox.Text = document.FilePath;
+                metaLabel.Text = string.Format("{0} | marker {1} | {2} entries", document.Header, document.Marker, document.Entries.Count);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to load PROP: " + ex.Message, "PROP Editor", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void SaveButton_Click(object sender, EventArgs e)
+        {
+            if (document == null)
+            {
+                MessageBox.Show("Open a .prop file first.", "PROP Editor", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
+
+            SaveFileDialog sfd = new SaveFileDialog();
+            sfd.Filter = "PROP files (*.prop)|*.prop|All files (*.*)|*.*";
+            sfd.FileName = Path.GetFileName(document.FilePath);
+
+            if (sfd.ShowDialog() != DialogResult.OK) return;
+
+            try
+            {
+                PropEditorWorker.Save(document, entries.Select(x => x.Value), sfd.FileName);
+                MessageBox.Show("Saved successfully.", "PROP Editor", MessageBoxButtons.OK, MessageBoxIcon.Information);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Failed to save PROP: " + ex.Message, "PROP Editor", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private void ReplaceAllButton_Click(object sender, EventArgs e)
+        {
+            if (string.IsNullOrEmpty(findTextBox.Text)) return;
+
+            int replacements = 0;
+            for (int i = 0; i < entries.Count; i++)
+            {
+                string original = entries[i].Value ?? string.Empty;
+                string updated = original.Replace(findTextBox.Text, replaceTextBox.Text ?? string.Empty);
+                if (updated != original)
+                {
+                    entries[i].Value = updated;
+                    replacements++;
+                }
+            }
+
+            grid.Refresh();
+            MessageBox.Show(string.Format("Replace finished. {0} row(s) changed.", replacements), "PROP Editor", MessageBoxButtons.OK, MessageBoxIcon.Information);
+        }
+
+        private void AddLineButton_Click(object sender, EventArgs e)
+        {
+            int nextIndex = entries.Count == 0 ? 1 : entries.Max(x => x.Index) + 1;
+            entries.Add(new PropEditorEntry { Index = nextIndex, Value = string.Empty });
+        }
+
+        private void RemoveLineButton_Click(object sender, EventArgs e)
+        {
+            if (grid.CurrentRow == null) return;
+
+            int selectedIndex = grid.CurrentRow.Index;
+            if (selectedIndex < 0 || selectedIndex >= entries.Count) return;
+
+            entries.RemoveAt(selectedIndex);
+
+            for (int i = 0; i < entries.Count; i++)
+            {
+                entries[i].Index = i + 1;
+            }
+
+            grid.Refresh();
+        }
+    }
+}

--- a/master/TTG Tools.csproj
+++ b/master/TTG Tools.csproj
@@ -172,6 +172,7 @@
     </Compile>
     <Compile Include="Methods.cs" />
     <Compile Include="Program.cs" />
+    <Compile Include="PropEditor.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Graphics\TextureWorker.cs" />
     <Compile Include="ClassesStructs\Text\CommonTextClass.cs" />
@@ -179,6 +180,7 @@
     <Compile Include="Texts\LandbWorker.cs" />
     <Compile Include="Texts\LangdbWorker.cs" />
     <Compile Include="Texts\ReadText.cs" />
+    <Compile Include="Texts\PropEditorWorker.cs" />
     <Compile Include="Texts\SaveText.cs" />
     <Compile Include="Updater.cs" />
     <Compile Include="Wrapper\OodleTools.cs" />

--- a/master/Texts/PropEditorWorker.cs
+++ b/master/Texts/PropEditorWorker.cs
@@ -1,0 +1,290 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace TTG_Tools.Texts
+{
+    public sealed class PropEditorDocument
+    {
+        public string FilePath { get; set; }
+        public string Header { get; set; }
+        public string Marker { get; set; }
+        public List<PropEditorEntry> Entries { get; private set; }
+
+        public PropEditorDocument()
+        {
+            Entries = new List<PropEditorEntry>();
+        }
+    }
+
+    public sealed class PropEditorEntry
+    {
+        public int Index { get; set; }
+        public string Value { get; set; }
+    }
+
+    public static class PropEditorWorker
+    {
+        private const string MarkerSimple = "B4-F4-5A-5F-60-6E-9C-CD";
+        private const string MarkerNested = "25-03-C6-1F-D8-64-1B-4F";
+
+        public static PropEditorDocument Load(string filePath)
+        {
+            PropEditorDocument document = new PropEditorDocument();
+            document.FilePath = filePath;
+
+            using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read))
+            using (BinaryReader br = new BinaryReader(fs))
+            {
+                byte[] headerBytes = br.ReadBytes(4);
+                document.Header = Encoding.ASCII.GetString(headerBytes);
+
+                if ((document.Header == "5VSM") || (document.Header == "6VSM"))
+                {
+                    br.ReadInt32();
+                    br.ReadInt64();
+                }
+
+                int countHeaders = br.ReadInt32();
+                for (int i = 0; i < countHeaders; i++)
+                {
+                    br.ReadBytes(8);
+                    br.ReadBytes(4);
+                }
+
+                br.ReadInt32();
+                br.ReadInt32();
+
+                if (document.Header != "6VSM")
+                {
+                    int blSize1 = br.ReadInt32();
+                    br.ReadBytes(blSize1 - 4);
+                }
+
+                br.ReadInt32();
+                br.ReadInt32();
+
+                if (document.Header == "6VSM")
+                {
+                    br.ReadInt32();
+                }
+
+                byte[] markerBytes = br.ReadBytes(8);
+                document.Marker = BitConverter.ToString(markerBytes);
+
+                if (document.Header == "ERTM")
+                {
+                    br.ReadInt32();
+                }
+
+                int countBlocks = br.ReadInt32();
+                int idx = 1;
+                Encoding txtEncoding = document.Header == "6VSM" ? Encoding.UTF8 : Encoding.GetEncoding(MainMenu.settings.ASCII_N);
+
+                if (document.Marker == MarkerSimple)
+                {
+                    for (int i = 0; i < countBlocks; i++)
+                    {
+                        br.ReadBytes(8);
+                        if (document.Header == "ERTM") br.ReadInt32();
+                        int len = br.ReadInt32();
+                        byte[] valueBytes = br.ReadBytes(len);
+                        document.Entries.Add(new PropEditorEntry { Index = idx++, Value = txtEncoding.GetString(valueBytes) });
+                    }
+                }
+                else if (document.Marker == MarkerNested)
+                {
+                    for (int i = 0; i < countBlocks; i++)
+                    {
+                        br.ReadBytes(8);
+                        if (document.Header == "ERTM") br.ReadInt32();
+
+                        int subCount = br.ReadInt32();
+                        for (int j = 0; j < subCount * 2; j++)
+                        {
+                            int len = br.ReadInt32();
+                            byte[] valueBytes = br.ReadBytes(len);
+                            document.Entries.Add(new PropEditorEntry { Index = idx++, Value = txtEncoding.GetString(valueBytes) });
+                        }
+                    }
+                }
+                else
+                {
+                    throw new InvalidDataException("PROP marker not supported by current editor: " + document.Marker);
+                }
+            }
+
+            return document;
+        }
+
+        public static void Save(PropEditorDocument document, IEnumerable<string> updatedValues, string outputPath)
+        {
+            List<string> values = updatedValues.Select(v => v ?? string.Empty).ToList();
+
+            byte[] binContent = File.ReadAllBytes(document.FilePath);
+            using (MemoryStream ms = new MemoryStream(binContent))
+            using (BinaryReader br = new BinaryReader(ms))
+            using (FileStream fs = new FileStream(outputPath, FileMode.Create, FileAccess.Write))
+            using (BinaryWriter bw = new BinaryWriter(fs))
+            {
+                int blockSize = 0;
+                int blHeadSize = 0;
+
+                byte[] header = br.ReadBytes(4);
+                string headerText = Encoding.ASCII.GetString(header);
+                bw.Write(header);
+
+                if ((headerText == "5VSM") || (headerText == "6VSM"))
+                {
+                    int oldHead = br.ReadInt32();
+                    bw.Write(oldHead);
+                    byte[] subBlock = br.ReadBytes(8);
+                    bw.Write(subBlock);
+                }
+
+                int count = br.ReadInt32();
+                bw.Write(count);
+                for (int i = 0; i < count; i++)
+                {
+                    bw.Write(br.ReadBytes(8));
+                    bw.Write(br.ReadBytes(4));
+                }
+
+                int one = br.ReadInt32();
+                bw.Write(one);
+                blHeadSize += 4;
+
+                int unknown = br.ReadInt32();
+                bw.Write(unknown);
+                blHeadSize += 4;
+
+                if (headerText != "6VSM")
+                {
+                    int blLen = br.ReadInt32();
+                    bw.Write(blLen);
+                    byte[] block = br.ReadBytes(blLen - 4);
+                    bw.Write(block);
+                    blHeadSize += blLen;
+                }
+
+                int posBlSize = (int)br.BaseStream.Position;
+                int orBlSize = br.ReadInt32();
+                bw.Write(orBlSize);
+                blockSize += 4;
+                blHeadSize += 4;
+
+                one = br.ReadInt32();
+                bw.Write(one);
+                blockSize += 4;
+                blHeadSize += 4;
+
+                if (headerText == "6VSM")
+                {
+                    one = br.ReadInt32();
+                    bw.Write(one);
+                    blockSize += 4;
+                    blHeadSize += 4;
+                }
+
+                byte[] marker = br.ReadBytes(8);
+                string markerText = BitConverter.ToString(marker);
+                bw.Write(marker);
+                blockSize += 8;
+                blHeadSize += 8;
+
+                if (headerText == "ERTM")
+                {
+                    one = br.ReadInt32();
+                    bw.Write(one);
+                    blockSize += 4;
+                }
+
+                count = br.ReadInt32();
+                bw.Write(count);
+                blockSize += 4;
+                blHeadSize += 4;
+
+                int c = 0;
+                Encoding txtEncoding = headerText == "6VSM" ? Encoding.UTF8 : Encoding.GetEncoding(MainMenu.settings.ASCII_N);
+
+                if (markerText == MarkerSimple)
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        bw.Write(br.ReadBytes(8));
+                        blockSize += 8;
+                        blHeadSize += 8;
+
+                        if (headerText == "ERTM")
+                        {
+                            one = br.ReadInt32();
+                            bw.Write(one);
+                            blockSize += 4;
+                        }
+
+                        int oldLen = br.ReadInt32();
+                        br.ReadBytes(oldLen);
+
+                        byte[] value = txtEncoding.GetBytes(c < values.Count ? values[c] : string.Empty);
+                        bw.Write(value.Length);
+                        bw.Write(value);
+
+                        blockSize += 4 + value.Length;
+                        blHeadSize += 4 + value.Length;
+                        c++;
+                    }
+                }
+                else if (markerText == MarkerNested)
+                {
+                    for (int i = 0; i < count; i++)
+                    {
+                        bw.Write(br.ReadBytes(8));
+                        blockSize += 8;
+                        blHeadSize += 8;
+
+                        if (headerText == "ERTM")
+                        {
+                            one = br.ReadInt32();
+                            bw.Write(one);
+                            blockSize += 4;
+                        }
+
+                        int subCount = br.ReadInt32();
+                        bw.Write(subCount);
+                        blockSize += 4;
+                        blHeadSize += 4;
+
+                        for (int j = 0; j < subCount * 2; j++)
+                        {
+                            int oldLen = br.ReadInt32();
+                            br.ReadBytes(oldLen);
+
+                            byte[] value = txtEncoding.GetBytes(c < values.Count ? values[c] : string.Empty);
+                            bw.Write(value.Length);
+                            bw.Write(value);
+
+                            blockSize += 4 + value.Length;
+                            blHeadSize += 4 + value.Length;
+                            c++;
+                        }
+                    }
+                }
+                else
+                {
+                    throw new InvalidDataException("PROP marker not supported by current editor: " + markerText);
+                }
+
+                bw.BaseStream.Seek(posBlSize, SeekOrigin.Begin);
+                bw.Write(blockSize);
+
+                if ((headerText == "5VSM") || (headerText == "6VSM"))
+                {
+                    bw.BaseStream.Seek(4, SeekOrigin.Begin);
+                    bw.Write(blHeadSize);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Fornecer edição direta de arquivos `.prop` dentro do TTG Tools sem passar por export/import externos, permitindo alterações em massa e regravação do binário mantendo a estrutura original.
- Reaproveitar a lógica já usada pelo projeto para leitura/escrita de PROP (marcadores e layouts conhecidos) para oferecer uma interface amigável de edição de textos.

### Description
- Adiciona a nova janela WinForms `PropEditor` com interface para abrir `.prop`, exibir e editar entradas em grade, `Find/Replace` em massa, adicionar/remover linhas, `Reload` e `Save As` (arquivo: `master/PropEditor.cs`).
- Implementa `PropEditorWorker` que faz parsing e reconstrói o binário de `.prop`, suportando os marcadores/formatos conhecidos `B4-F4-5A-5F-60-6E-9C-CD` e `25-03-C6-1F-D8-64-1B-4F` e preservando cálculo de tamanhos/blocos (arquivo: `master/Texts/PropEditorWorker.cs`).
- Integra o editor ao menu principal com novo botão **Prop Editor** e handler para abrir a janela sem duplicar instâncias (arquivos: `master/MainMenu.Designer.cs`, `master/MainMenu.cs`).
- Registra os novos arquivos no projeto para compilação adicionando `PropEditor.cs` e `Texts\PropEditorWorker.cs` a `master/TTG Tools.csproj`.