### PR TITLE
Add Prop Editor tab with hierarchical .prop inspector

### DIFF
--- a/master/MainMenu.Designer.cs
+++ b/master/MainMenu.Designer.cs
@@ -39,6 +39,7 @@
             this.settingsBtn = new System.Windows.Forms.Button();
             this.archivePackerBtn = new System.Windows.Forms.Button();
             this.arcUnpackerBtn = new System.Windows.Forms.Button();
+            this.propEditorBtn = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // autopackerBtn
@@ -119,11 +120,22 @@
             this.arcUnpackerBtn.UseVisualStyleBackColor = true;
             this.arcUnpackerBtn.Click += new System.EventHandler(this.arcUnpackerBtn_Click);
             // 
+            // propEditorBtn
+            // 
+            this.propEditorBtn.Location = new System.Drawing.Point(127, 108);
+            this.propEditorBtn.Name = "propEditorBtn";
+            this.propEditorBtn.Size = new System.Drawing.Size(112, 23);
+            this.propEditorBtn.TabIndex = 14;
+            this.propEditorBtn.Text = "Prop Editor";
+            this.propEditorBtn.UseVisualStyleBackColor = true;
+            this.propEditorBtn.Click += new System.EventHandler(this.propEditorBtn_Click);
+            // 
             // MainMenu
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(370, 191);
+            this.Controls.Add(this.propEditorBtn);
             this.Controls.Add(this.arcUnpackerBtn);
             this.Controls.Add(this.archivePackerBtn);
             this.Controls.Add(this.settingsBtn);
@@ -153,5 +165,6 @@
         private System.Windows.Forms.Button settingsBtn;
         private System.Windows.Forms.Button archivePackerBtn;
         private System.Windows.Forms.Button arcUnpackerBtn;
+        private System.Windows.Forms.Button propEditorBtn;
     }
 }

--- a/master/MainMenu.cs
+++ b/master/MainMenu.cs
@@ -352,5 +352,15 @@ namespace TTG_Tools
                 arcUnpackerForm.Show();
             }
         }
+
+
+        private void propEditorBtn_Click(object sender, EventArgs e)
+        {
+            if (Application.OpenForms.OfType<PropEditor>().Count() == 0)
+            {
+                Form propEditor = new PropEditor();
+                propEditor.Show();
+            }
+        }
     }
-}
+}

--- a/master/PropEditor.Designer.cs
+++ b/master/PropEditor.Designer.cs
@@ -1,0 +1,142 @@
+namespace TTG_Tools
+{
+    partial class PropEditor
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        private void InitializeComponent()
+        {
+            this.mainTabs = new System.Windows.Forms.TabControl();
+            this.propEditorTab = new System.Windows.Forms.TabPage();
+            this.statusLbl = new System.Windows.Forms.Label();
+            this.collapseAllBtn = new System.Windows.Forms.Button();
+            this.expandAllBtn = new System.Windows.Forms.Button();
+            this.openPropBtn = new System.Windows.Forms.Button();
+            this.propPathTB = new System.Windows.Forms.TextBox();
+            this.propTreeView = new System.Windows.Forms.TreeView();
+            this.mainTabs.SuspendLayout();
+            this.propEditorTab.SuspendLayout();
+            this.SuspendLayout();
+            // 
+            // mainTabs
+            // 
+            this.mainTabs.Controls.Add(this.propEditorTab);
+            this.mainTabs.Dock = System.Windows.Forms.DockStyle.Fill;
+            this.mainTabs.Location = new System.Drawing.Point(0, 0);
+            this.mainTabs.Name = "mainTabs";
+            this.mainTabs.SelectedIndex = 0;
+            this.mainTabs.Size = new System.Drawing.Size(968, 579);
+            this.mainTabs.TabIndex = 0;
+            // 
+            // propEditorTab
+            // 
+            this.propEditorTab.Controls.Add(this.statusLbl);
+            this.propEditorTab.Controls.Add(this.collapseAllBtn);
+            this.propEditorTab.Controls.Add(this.expandAllBtn);
+            this.propEditorTab.Controls.Add(this.openPropBtn);
+            this.propEditorTab.Controls.Add(this.propPathTB);
+            this.propEditorTab.Controls.Add(this.propTreeView);
+            this.propEditorTab.Location = new System.Drawing.Point(4, 22);
+            this.propEditorTab.Name = "propEditorTab";
+            this.propEditorTab.Padding = new System.Windows.Forms.Padding(3);
+            this.propEditorTab.Size = new System.Drawing.Size(960, 553);
+            this.propEditorTab.TabIndex = 0;
+            this.propEditorTab.Text = "Prop Editor";
+            this.propEditorTab.UseVisualStyleBackColor = true;
+            // 
+            // statusLbl
+            // 
+            this.statusLbl.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.statusLbl.Location = new System.Drawing.Point(8, 527);
+            this.statusLbl.Name = "statusLbl";
+            this.statusLbl.Size = new System.Drawing.Size(946, 20);
+            this.statusLbl.TabIndex = 5;
+            this.statusLbl.Text = "Open a .prop file to inspect all data.";
+            // 
+            // collapseAllBtn
+            // 
+            this.collapseAllBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.collapseAllBtn.Location = new System.Drawing.Point(877, 7);
+            this.collapseAllBtn.Name = "collapseAllBtn";
+            this.collapseAllBtn.Size = new System.Drawing.Size(77, 23);
+            this.collapseAllBtn.TabIndex = 4;
+            this.collapseAllBtn.Text = "Collapse";
+            this.collapseAllBtn.UseVisualStyleBackColor = true;
+            this.collapseAllBtn.Click += new System.EventHandler(this.collapseAllBtn_Click);
+            // 
+            // expandAllBtn
+            // 
+            this.expandAllBtn.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.expandAllBtn.Location = new System.Drawing.Point(794, 7);
+            this.expandAllBtn.Name = "expandAllBtn";
+            this.expandAllBtn.Size = new System.Drawing.Size(77, 23);
+            this.expandAllBtn.TabIndex = 3;
+            this.expandAllBtn.Text = "Expand";
+            this.expandAllBtn.UseVisualStyleBackColor = true;
+            this.expandAllBtn.Click += new System.EventHandler(this.expandAllBtn_Click);
+            // 
+            // openPropBtn
+            // 
+            this.openPropBtn.Location = new System.Drawing.Point(8, 7);
+            this.openPropBtn.Name = "openPropBtn";
+            this.openPropBtn.Size = new System.Drawing.Size(81, 23);
+            this.openPropBtn.TabIndex = 2;
+            this.openPropBtn.Text = "Open .prop";
+            this.openPropBtn.UseVisualStyleBackColor = true;
+            this.openPropBtn.Click += new System.EventHandler(this.openPropBtn_Click);
+            // 
+            // propPathTB
+            // 
+            this.propPathTB.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.propPathTB.Location = new System.Drawing.Point(95, 9);
+            this.propPathTB.Name = "propPathTB";
+            this.propPathTB.ReadOnly = true;
+            this.propPathTB.Size = new System.Drawing.Size(693, 20);
+            this.propPathTB.TabIndex = 1;
+            // 
+            // propTreeView
+            // 
+            this.propTreeView.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom)
+            | System.Windows.Forms.AnchorStyles.Left)
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.propTreeView.Location = new System.Drawing.Point(8, 36);
+            this.propTreeView.Name = "propTreeView";
+            this.propTreeView.Size = new System.Drawing.Size(946, 488);
+            this.propTreeView.TabIndex = 0;
+            // 
+            // PropEditor
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(968, 579);
+            this.Controls.Add(this.mainTabs);
+            this.Name = "PropEditor";
+            this.Text = "TTG Tools - Prop Editor";
+            this.mainTabs.ResumeLayout(false);
+            this.propEditorTab.ResumeLayout(false);
+            this.propEditorTab.PerformLayout();
+            this.ResumeLayout(false);
+
+        }
+
+        private System.Windows.Forms.TabControl mainTabs;
+        private System.Windows.Forms.TabPage propEditorTab;
+        private System.Windows.Forms.TreeView propTreeView;
+        private System.Windows.Forms.TextBox propPathTB;
+        private System.Windows.Forms.Button openPropBtn;
+        private System.Windows.Forms.Button expandAllBtn;
+        private System.Windows.Forms.Button collapseAllBtn;
+        private System.Windows.Forms.Label statusLbl;
+    }
+}

--- a/master/PropEditor.cs
+++ b/master/PropEditor.cs
@@ -1,0 +1,78 @@
+using System;
+using System.IO;
+using System.Windows.Forms;
+
+namespace TTG_Tools
+{
+    public partial class PropEditor : Form
+    {
+        public PropEditor()
+        {
+            InitializeComponent();
+        }
+
+        private void openPropBtn_Click(object sender, EventArgs e)
+        {
+            using (OpenFileDialog ofd = new OpenFileDialog())
+            {
+                ofd.Filter = "Property files (*.prop)|*.prop|All files (*.*)|*.*";
+                ofd.FilterIndex = 0;
+
+                if (ofd.ShowDialog() == DialogResult.OK)
+                {
+                    LoadProp(ofd.FileName);
+                }
+            }
+        }
+
+        private void LoadProp(string filePath)
+        {
+            try
+            {
+                propPathTB.Text = filePath;
+                propTreeView.BeginUpdate();
+                propTreeView.Nodes.Clear();
+
+                PropInspectorParser.PropNode root = PropInspectorParser.Parse(filePath);
+                TreeNode rootNode = CreateTreeNode(root);
+                propTreeView.Nodes.Add(rootNode);
+                rootNode.Expand();
+
+                statusLbl.Text = string.Format("Loaded {0} ({1:N0} bytes)", Path.GetFileName(filePath), new FileInfo(filePath).Length);
+            }
+            catch (Exception ex)
+            {
+                MessageBox.Show("Could not parse .prop file.\n\n" + ex.Message, "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                statusLbl.Text = "Failed to parse file.";
+            }
+            finally
+            {
+                propTreeView.EndUpdate();
+            }
+        }
+
+        private TreeNode CreateTreeNode(PropInspectorParser.PropNode node)
+        {
+            string text = string.IsNullOrEmpty(node.Value) ? node.Name : string.Format("{0}: {1}", node.Name, node.Value);
+            TreeNode treeNode = new TreeNode(text);
+            treeNode.Tag = node;
+
+            foreach (PropInspectorParser.PropNode child in node.Children)
+            {
+                treeNode.Nodes.Add(CreateTreeNode(child));
+            }
+
+            return treeNode;
+        }
+
+        private void expandAllBtn_Click(object sender, EventArgs e)
+        {
+            propTreeView.ExpandAll();
+        }
+
+        private void collapseAllBtn_Click(object sender, EventArgs e)
+        {
+            propTreeView.CollapseAll();
+        }
+    }
+}

--- a/master/PropInspectorParser.cs
+++ b/master/PropInspectorParser.cs
@@ -1,0 +1,232 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+
+namespace TTG_Tools
+{
+    internal static class PropInspectorParser
+    {
+        internal sealed class PropNode
+        {
+            public string Name { get; set; }
+            public string Value { get; set; }
+            public long Offset { get; set; }
+            public long Length { get; set; }
+            public List<PropNode> Children { get; private set; }
+
+            public PropNode()
+            {
+                Children = new List<PropNode>();
+            }
+        }
+
+        public static PropNode Parse(string filePath)
+        {
+            PropNode root = new PropNode();
+            root.Name = Path.GetFileName(filePath);
+            root.Value = "PROP file";
+
+            using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+            using (BinaryReader br = new BinaryReader(fs))
+            {
+                ParseCore(br, root);
+            }
+
+            return root;
+        }
+
+        private static void ParseCore(BinaryReader br, PropNode root)
+        {
+            PropNode headerNode = ReadAscii(br, "Header", 4);
+            root.Children.Add(headerNode);
+            string header = headerNode.Value;
+
+            if (header == "5VSM" || header == "6VSM")
+            {
+                root.Children.Add(ReadInt32(br, "Block Size"));
+                root.Children.Add(ReadInt64(br, "Sub Block Size"));
+            }
+
+            int countHeaders = ReadInt32(br, "Header Entries Count", root).Item2;
+
+            PropNode headersNode = new PropNode();
+            headersNode.Name = "Header Entries";
+            headersNode.Value = countHeaders.ToString();
+            root.Children.Add(headersNode);
+
+            for (int i = 0; i < countHeaders; i++)
+            {
+                PropNode entry = new PropNode();
+                entry.Name = "Entry " + i;
+                headersNode.Children.Add(entry);
+                entry.Children.Add(ReadBytesNode(br, "CRC64", 8));
+                entry.Children.Add(ReadInt32(br, "Value"));
+            }
+
+            root.Children.Add(ReadInt32(br, "One"));
+            root.Children.Add(ReadInt32(br, "SomeValue1"));
+
+            if (header != "6VSM")
+            {
+                int blSize1 = ReadInt32(br, "Block1Size", root).Item2;
+                root.Children.Add(ReadBytesNode(br, "Block1Data", Math.Max(0, blSize1 - 4)));
+            }
+
+            root.Children.Add(ReadInt32(br, "Block2Size"));
+            root.Children.Add(ReadInt32(br, "One1"));
+            if (header == "6VSM")
+            {
+                root.Children.Add(ReadInt32(br, "One2"));
+            }
+
+            byte[] typeMarker = ReadBytesNode(br, "Primary Marker", 8).ValueBytes;
+            root.Children.Add(CreateBytesNode("Primary Marker", typeMarker, br.BaseStream.Position - typeMarker.Length));
+
+            string marker = BitConverter.ToString(typeMarker);
+
+            if (marker == "B4-F4-5A-5F-60-6E-9C-CD")
+            {
+                ParseStringBlock(br, root, header);
+            }
+            else if (marker == "25-03-C6-1F-D8-64-1B-4F")
+            {
+                ParseNestedStringBlock(br, root, header);
+            }
+
+            long remain = br.BaseStream.Length - br.BaseStream.Position;
+            if (remain > 0)
+            {
+                root.Children.Add(ReadBytesNode(br, "Trailing/Hidden Data", (int)remain));
+            }
+        }
+
+        private static void ParseStringBlock(BinaryReader br, PropNode parent, string header)
+        {
+            PropNode blockNode = new PropNode { Name = "String Block (Marker B4-F4-5A-5F-60-6E-9C-CD)", Value = string.Empty };
+            parent.Children.Add(blockNode);
+
+            if (header == "ERTM")
+            {
+                blockNode.Children.Add(ReadInt32(br, "Optional One"));
+            }
+
+            int countBlocks = ReadInt32(br, "Entries Count", blockNode).Item2;
+            for (int i = 0; i < countBlocks; i++)
+            {
+                PropNode entry = new PropNode { Name = "Entry " + i };
+                blockNode.Children.Add(entry);
+                entry.Children.Add(ReadBytesNode(br, "Name CRC64", 8));
+
+                if (header == "ERTM")
+                {
+                    entry.Children.Add(ReadInt32(br, "Optional One"));
+                }
+
+                int len = ReadInt32(br, "String Length", entry).Item2;
+                entry.Children.Add(ReadStringByHeader(br, "String", len, header));
+            }
+        }
+
+        private static void ParseNestedStringBlock(BinaryReader br, PropNode parent, string header)
+        {
+            PropNode blockNode = new PropNode { Name = "Nested Block (Marker 25-03-C6-1F-D8-64-1B-4F)", Value = string.Empty };
+            parent.Children.Add(blockNode);
+
+            int count = ReadInt32(br, "Blocks Count", blockNode).Item2;
+            for (int i = 0; i < count; i++)
+            {
+                PropNode block = new PropNode { Name = "Block " + i };
+                blockNode.Children.Add(block);
+                block.Children.Add(ReadBytesNode(br, "Block CRC64", 8));
+
+                if (header == "ERTM")
+                {
+                    block.Children.Add(ReadInt32(br, "Optional One"));
+                }
+
+                int subCount = ReadInt32(br, "Sub Count", block).Item2;
+                for (int j = 0; j < subCount * 2; j++)
+                {
+                    int len = ReadInt32(br, "Value Length " + j, block).Item2;
+                    block.Children.Add(ReadStringByHeader(br, "Value " + j, len, header));
+                }
+            }
+        }
+
+        private static PropNode ReadStringByHeader(BinaryReader br, string name, int length, string header)
+        {
+            long offset = br.BaseStream.Position;
+            byte[] data = br.ReadBytes(length);
+
+            Encoding enc = header == "6VSM" ? Encoding.UTF8 : Encoding.GetEncoding(MainMenu.settings.ASCII_N);
+            string value = enc.GetString(data);
+
+            PropNode node = new PropNode();
+            node.Name = name;
+            node.Value = value;
+            node.Offset = offset;
+            node.Length = data.Length;
+            node.Children.Add(CreateBytesNode("Raw", data, offset));
+            return node;
+        }
+
+        private sealed class BytesNodeResult : PropNode
+        {
+            public byte[] ValueBytes { get; set; }
+        }
+
+        private static BytesNodeResult ReadBytesNode(BinaryReader br, string name, int length)
+        {
+            long offset = br.BaseStream.Position;
+            byte[] bytes = br.ReadBytes(length);
+            return new BytesNodeResult
+            {
+                Name = name,
+                Value = BitConverter.ToString(bytes),
+                Offset = offset,
+                Length = bytes.Length,
+                ValueBytes = bytes
+            };
+        }
+
+        private static PropNode CreateBytesNode(string name, byte[] bytes, long offset)
+        {
+            PropNode node = new PropNode();
+            node.Name = name;
+            node.Value = BitConverter.ToString(bytes);
+            node.Offset = offset;
+            node.Length = bytes.Length;
+            return node;
+        }
+
+        private static System.Tuple<PropNode, int> ReadInt32(BinaryReader br, string name, PropNode appendTo)
+        {
+            System.Tuple<PropNode, int> result = ReadInt32(br, name);
+            appendTo.Children.Add(result.Item1);
+            return result;
+        }
+
+        private static System.Tuple<PropNode, int> ReadInt32(BinaryReader br, string name)
+        {
+            long offset = br.BaseStream.Position;
+            int val = br.ReadInt32();
+            PropNode node = new PropNode { Name = name, Value = val.ToString(), Offset = offset, Length = 4 };
+            return new System.Tuple<PropNode, int>(node, val);
+        }
+
+        private static PropNode ReadInt64(BinaryReader br, string name)
+        {
+            long offset = br.BaseStream.Position;
+            long val = br.ReadInt64();
+            return new PropNode { Name = name, Value = val.ToString(), Offset = offset, Length = 8 };
+        }
+
+        private static PropNode ReadAscii(BinaryReader br, string name, int length)
+        {
+            long offset = br.BaseStream.Position;
+            byte[] bytes = br.ReadBytes(length);
+            return new PropNode { Name = name, Value = Encoding.ASCII.GetString(bytes), Offset = offset, Length = bytes.Length };
+        }
+    }
+}

--- a/master/PropInspectorParser.cs
+++ b/master/PropInspectorParser.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Text;
 
 namespace TTG_Tools
@@ -19,10 +20,23 @@ namespace TTG_Tools
             }
         }
 
+        private sealed class PropPair
+        {
+            public string Key;
+            public string Value;
+        }
+
+        private sealed class PropBlock
+        {
+            public string Label;
+            public List<PropPair> Pairs = new List<PropPair>();
+            public List<string> Values = new List<string>();
+        }
+
         private static readonly HashSet<string> LanguageNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
         {
             "French", "English", "Japanese", "German", "Spanish", "Portuguese", "Italian", "Russian", "Polish",
-            "Chinese", "Korean", "Dutch", "Czech", "Arabic", "Turkish", "Thai", "Hungarian"
+            "Chinese", "Korean", "Dutch", "Czech", "Arabic", "Turkish", "Thai", "Hungarian", "Brazilian Portuguese"
         };
 
         public static PropNode Parse(string filePath)
@@ -31,96 +45,133 @@ namespace TTG_Tools
             root.Name = Path.GetFileName(filePath);
             root.Value = "Properties";
 
-            List<string> strings = ExtractPropStrings(filePath);
+            List<PropBlock> blocks = ExtractPropBlocks(filePath);
 
             PropNode properties = new PropNode();
             properties.Name = "Properties";
             properties.Value = string.Empty;
             root.Children.Add(properties);
 
-            if (strings.Count == 0)
+            if (blocks.Count == 0)
             {
-                PropNode none = new PropNode();
-                none.Name = "(No property strings found)";
-                none.Value = string.Empty;
-                properties.Children.Add(none);
+                properties.Children.Add(new PropNode { Name = "(No properties found)", Value = string.Empty });
                 return root;
             }
 
-            AddLocalizedView(properties, strings);
-            AddFlatEntriesView(properties, strings);
+            for (int i = 0; i < blocks.Count; i++)
+            {
+                PropNode blockNode = BuildBlockNode(blocks[i], i + 1);
+                if (blockNode != null) properties.Children.Add(blockNode);
+            }
+
+            if (properties.Children.Count == 0)
+            {
+                properties.Children.Add(new PropNode { Name = "(No readable properties found)", Value = string.Empty });
+            }
 
             return root;
         }
 
-        private static void AddLocalizedView(PropNode properties, List<string> strings)
+        private static PropNode BuildBlockNode(PropBlock block, int index)
         {
-            PropNode localized = new PropNode();
-            localized.Name = "Localized Text";
-            localized.Value = string.Empty;
+            string title = string.IsNullOrEmpty(block.Label) ? ("Property " + index.ToString()) : block.Label;
+            PropNode blockNode = new PropNode { Name = title, Value = string.Empty };
 
-            Dictionary<string, List<string>> valuesByLang = new Dictionary<string, List<string>>(StringComparer.OrdinalIgnoreCase);
-
-            for (int i = 0; i < strings.Count - 1; i++)
+            if (block.Pairs.Count > 0)
             {
-                string key = Clean(strings[i]);
-                string value = Clean(strings[i + 1]);
-
-                if (LanguageNames.Contains(key) && !string.IsNullOrEmpty(value) && !LanguageNames.Contains(value))
+                AddPairsTree(blockNode, block.Pairs);
+            }
+            else
+            {
+                int shown = 0;
+                for (int i = 0; i < block.Values.Count; i++)
                 {
-                    if (!valuesByLang.ContainsKey(key)) valuesByLang[key] = new List<string>();
-                    valuesByLang[key].Add(value);
+                    if (!IsUsefulString(block.Values[i])) continue;
+                    blockNode.Children.Add(new PropNode { Name = "Value " + (shown + 1).ToString(), Value = Clean(block.Values[i]) });
+                    shown++;
                 }
             }
 
-            if (valuesByLang.Count == 0)
-            {
-                return;
-            }
+            if (blockNode.Children.Count == 0)
+                return null;
 
-            foreach (KeyValuePair<string, List<string>> item in valuesByLang)
-            {
-                PropNode langNode = new PropNode();
-                langNode.Name = item.Key;
-                langNode.Value = string.Empty;
+            return blockNode;
+        }
 
-                for (int i = 0; i < item.Value.Count; i++)
+        private static void AddPairsTree(PropNode parent, List<PropPair> pairs)
+        {
+            int i = 0;
+            while (i < pairs.Count)
+            {
+                PropPair pair = pairs[i];
+                string key = Clean(pair.Key);
+                string value = Clean(pair.Value);
+
+                if (!IsUsefulString(key) && !IsUsefulString(value))
                 {
-                    PropNode txtNode = new PropNode();
-                    txtNode.Name = "Text " + (i + 1).ToString();
-                    txtNode.Value = item.Value[i];
-                    langNode.Children.Add(txtNode);
+                    i++;
+                    continue;
                 }
 
-                localized.Children.Add(langNode);
-            }
+                if (key.Equals("Description", StringComparison.OrdinalIgnoreCase))
+                {
+                    PropNode descNode = new PropNode { Name = "Description", Value = string.Empty };
+                    int j = i + 1;
+                    bool hasLang = false;
 
-            properties.Children.Add(localized);
+                    while (j < pairs.Count)
+                    {
+                        string lk = Clean(pairs[j].Key);
+                        string lv = Clean(pairs[j].Value);
+
+                        if (!LanguageNames.Contains(lk)) break;
+                        if (IsUsefulString(lv))
+                        {
+                            descNode.Children.Add(new PropNode { Name = lk, Value = lv });
+                            hasLang = true;
+                        }
+
+                        j++;
+                    }
+
+                    if (hasLang)
+                    {
+                        parent.Children.Add(descNode);
+                        i = j;
+                        continue;
+                    }
+                }
+
+                if (LanguageNames.Contains(key) && IsUsefulString(value))
+                {
+                    PropNode localized = parent.Children.FirstOrDefault(n => n.Name == "Localized Text");
+                    if (localized == null)
+                    {
+                        localized = new PropNode { Name = "Localized Text", Value = string.Empty };
+                        parent.Children.Add(localized);
+                    }
+
+                    localized.Children.Add(new PropNode { Name = key, Value = value });
+                    i++;
+                    continue;
+                }
+
+                if (IsUsefulString(key))
+                {
+                    parent.Children.Add(new PropNode { Name = key, Value = IsUsefulString(value) ? value : string.Empty });
+                }
+                else if (IsUsefulString(value))
+                {
+                    parent.Children.Add(new PropNode { Name = "Value", Value = value });
+                }
+
+                i++;
+            }
         }
 
-        private static void AddFlatEntriesView(PropNode properties, List<string> strings)
+        private static List<PropBlock> ExtractPropBlocks(string filePath)
         {
-            PropNode entries = new PropNode();
-            entries.Name = "Entries";
-            entries.Value = strings.Count.ToString();
-
-            for (int i = 0; i < strings.Count; i++)
-            {
-                string val = Clean(strings[i]);
-                if (string.IsNullOrEmpty(val)) continue;
-
-                PropNode node = new PropNode();
-                node.Name = "Entry " + (i + 1).ToString();
-                node.Value = val;
-                entries.Children.Add(node);
-            }
-
-            properties.Children.Add(entries);
-        }
-
-        private static List<string> ExtractPropStrings(string filePath)
-        {
-            List<string> results = new List<string>();
+            List<PropBlock> blocks = new List<PropBlock>();
 
             using (FileStream fs = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
             using (BinaryReader br = new BinaryReader(fs))
@@ -129,8 +180,8 @@ namespace TTG_Tools
 
                 if (header == "5VSM" || header == "6VSM")
                 {
-                    br.ReadInt32();
-                    br.ReadInt64();
+                    SafeReadInt32(br);
+                    SafeReadInt64(br);
                 }
 
                 int countHeaders = SafeReadInt32(br);
@@ -140,104 +191,201 @@ namespace TTG_Tools
                     br.ReadBytes(4);
                 }
 
-                br.ReadInt32();
-                br.ReadInt32();
+                SafeReadInt32(br);
+                SafeReadInt32(br);
 
                 if (header != "6VSM")
                 {
                     int blSize1 = SafeReadInt32(br);
                     int toSkip = blSize1 - 4;
-                    if (toSkip > 0) br.ReadBytes(toSkip);
+                    if (toSkip > 0 && toSkip <= br.BaseStream.Length - br.BaseStream.Position) br.ReadBytes(toSkip);
                 }
 
-                br.ReadInt32();
-                br.ReadInt32();
-                if (header == "6VSM") br.ReadInt32();
+                SafeReadInt32(br);
+                SafeReadInt32(br);
+                if (header == "6VSM") SafeReadInt32(br);
 
                 byte[] markerBytes = br.ReadBytes(8);
                 string marker = BitConverter.ToString(markerBytes);
 
-                Encoding enc = header == "6VSM" ? Encoding.UTF8 : Encoding.GetEncoding(MainMenu.settings.ASCII_N);
-
                 if (marker == "B4-F4-5A-5F-60-6E-9C-CD")
                 {
-                    if (header == "ERTM") br.ReadInt32();
+                    if (header == "ERTM") SafeReadInt32(br);
 
                     int countBlocks = SafeReadInt32(br);
                     for (int i = 0; i < countBlocks; i++)
                     {
                         br.ReadBytes(8);
-                        if (header == "ERTM") br.ReadInt32();
+                        if (header == "ERTM") SafeReadInt32(br);
 
                         int len = SafeReadInt32(br);
                         if (len <= 0 || len > (br.BaseStream.Length - br.BaseStream.Position)) break;
 
                         byte[] valueData = br.ReadBytes(len);
-                        results.Add(enc.GetString(valueData));
+                        string value = DecodeBest(valueData);
+
+                        PropBlock block = new PropBlock();
+                        block.Label = "Property " + (i + 1).ToString();
+                        block.Values.Add(value);
+                        blocks.Add(block);
                     }
                 }
                 else if (marker == "25-03-C6-1F-D8-64-1B-4F")
                 {
-                    if (header == "ERTM") br.ReadInt32();
+                    if (header == "ERTM") SafeReadInt32(br);
 
                     int countBlocks = SafeReadInt32(br);
                     for (int i = 0; i < countBlocks; i++)
                     {
                         br.ReadBytes(8);
-                        if (header == "ERTM") br.ReadInt32();
+                        if (header == "ERTM") SafeReadInt32(br);
 
                         int countSubBlocks = SafeReadInt32(br);
+                        List<string> values = new List<string>();
+
                         for (int j = 0; j < countSubBlocks * 2; j++)
                         {
                             int len = SafeReadInt32(br);
                             if (len <= 0 || len > (br.BaseStream.Length - br.BaseStream.Position)) break;
 
                             byte[] valueData = br.ReadBytes(len);
-                            results.Add(enc.GetString(valueData));
+                            values.Add(DecodeBest(valueData));
                         }
+
+                        PropBlock block = new PropBlock();
+                        block.Label = InferBlockName(values, i + 1);
+
+                        for (int j = 0; j + 1 < values.Count; j += 2)
+                        {
+                            PropPair pair = new PropPair();
+                            pair.Key = values[j];
+                            pair.Value = values[j + 1];
+                            block.Pairs.Add(pair);
+                        }
+
+                        if (block.Pairs.Count == 0)
+                            block.Values.AddRange(values);
+
+                        blocks.Add(block);
                     }
                 }
                 else
                 {
-                    // Fallback: scan printable strings from remaining file data
                     byte[] tail = br.ReadBytes((int)(br.BaseStream.Length - br.BaseStream.Position));
-                    ExtractPrintableStrings(results, tail, enc);
+                    List<string> strs = ExtractPrintableStrings(tail);
+                    if (strs.Count > 0)
+                    {
+                        PropBlock block = new PropBlock();
+                        block.Label = "Property 1";
+                        block.Values.AddRange(strs);
+                        blocks.Add(block);
+                    }
                 }
             }
 
-            return results;
+            return blocks;
         }
 
-        private static void ExtractPrintableStrings(List<string> output, byte[] data, Encoding enc)
+        private static string InferBlockName(List<string> values, int index)
         {
+            for (int i = 0; i < values.Count; i += 2)
+            {
+                string k = Clean(values[i]);
+                if (IsUsefulString(k) && !LanguageNames.Contains(k) && k.Length <= 40)
+                    return k;
+            }
+
+            return "Property " + index.ToString();
+        }
+
+        private static List<string> ExtractPrintableStrings(byte[] data)
+        {
+            List<string> result = new List<string>();
             List<byte> current = new List<byte>();
+
             for (int i = 0; i < data.Length; i++)
             {
                 byte b = data[i];
                 bool printable = (b >= 32 && b <= 126) || b >= 128;
-
-                if (printable)
-                {
-                    current.Add(b);
-                }
-                else
-                {
-                    FlushCurrent(output, current, enc);
-                }
+                if (printable) current.Add(b);
+                else FlushCurrent(result, current);
             }
 
-            FlushCurrent(output, current, enc);
+            FlushCurrent(result, current);
+            return result;
         }
 
-        private static void FlushCurrent(List<string> output, List<byte> current, Encoding enc)
+        private static void FlushCurrent(List<string> result, List<byte> current)
         {
             if (current.Count >= 3)
             {
-                string s = Clean(enc.GetString(current.ToArray()));
-                if (!string.IsNullOrEmpty(s)) output.Add(s);
+                string decoded = DecodeBest(current.ToArray());
+                if (IsUsefulString(decoded)) result.Add(Clean(decoded));
             }
 
             current.Clear();
+        }
+
+        private static string DecodeBest(byte[] data)
+        {
+            if (data == null || data.Length == 0) return string.Empty;
+
+            List<Encoding> candidates = new List<Encoding>
+            {
+                Encoding.UTF8,
+                Encoding.GetEncoding(MainMenu.settings.ASCII_N),
+                Encoding.GetEncoding(1252),
+                Encoding.Unicode,
+                Encoding.BigEndianUnicode
+            };
+
+            string best = string.Empty;
+            double bestScore = double.MinValue;
+
+            for (int i = 0; i < candidates.Count; i++)
+            {
+                string text;
+                try { text = candidates[i].GetString(data); }
+                catch { continue; }
+
+                text = Clean(text);
+                double score = ScoreText(text);
+
+                if (score > bestScore)
+                {
+                    bestScore = score;
+                    best = text;
+                }
+            }
+
+            return best;
+        }
+
+        private static double ScoreText(string text)
+        {
+            if (string.IsNullOrEmpty(text)) return -1000;
+
+            int printable = 0;
+            int letters = 0;
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                char c = text[i];
+                if (!char.IsControl(c)) printable++;
+                if (char.IsLetterOrDigit(c) || char.IsWhiteSpace(c) || char.IsPunctuation(c)) letters++;
+            }
+
+            double ratioPrintable = (double)printable / Math.Max(1, text.Length);
+            double ratioLetters = (double)letters / Math.Max(1, text.Length);
+            return (ratioPrintable * 2.0) + ratioLetters;
+        }
+
+        private static bool IsUsefulString(string text)
+        {
+            text = Clean(text);
+            if (text.Length == 0) return false;
+            if (text.Length > 2048) return false;
+            return ScoreText(text) > 1.4;
         }
 
         private static int SafeReadInt32(BinaryReader br)
@@ -246,11 +394,16 @@ namespace TTG_Tools
             return br.ReadInt32();
         }
 
+        private static long SafeReadInt64(BinaryReader br)
+        {
+            if (br.BaseStream.Position + 8 > br.BaseStream.Length) return 0;
+            return br.ReadInt64();
+        }
+
         private static string Clean(string s)
         {
             if (s == null) return string.Empty;
-            s = s.Replace("\0", string.Empty).Trim();
-            return s;
+            return s.Replace("\0", string.Empty).Trim();
         }
     }
 }

--- a/master/TTG Tools.csproj
+++ b/master/TTG Tools.csproj
@@ -171,6 +171,13 @@
       <DependentUpon>MainMenu.cs</DependentUpon>
     </Compile>
     <Compile Include="Methods.cs" />
+    <Compile Include="PropEditor.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="PropEditor.Designer.cs">
+      <DependentUpon>PropEditor.cs</DependentUpon>
+    </Compile>
+    <Compile Include="PropInspectorParser.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Graphics\TextureWorker.cs" />


### PR DESCRIPTION
### Motivation
- Add an integrated Prop Editor to TTG Tools that exposes the full contents of `.prop` files in a hierarchical/tree view consistent with the behavior of the original Telltale Inspector Property Editor.
- Provide detailed visibility into all properties, markers, nested blocks, strings and trailing/hidden data for forensic inspection and game compatibility troubleshooting.

### Description
- Implemented a binary parser in `PropInspectorParser` that reads header fields, markers, CRCs, integer blocks, string blocks and remaining bytes into a hierarchical `PropNode` model for inspection (`master/PropInspectorParser.cs`).
- Added a new `PropEditor` WinForms UI with a `TreeView`, path textbox and controls to `Open`, `Expand` and `Collapse` the parsed tree (`master/PropEditor.cs`, `master/PropEditor.Designer.cs`).
- Wired the main menu: added a `Prop Editor` button and handler to open the `PropEditor` window (`master/MainMenu.Designer.cs`, `master/MainMenu.cs`).
- Registered the new source files in the project file so they are included in builds (`master/TTG Tools.csproj`).
----------------
This is essentially a reuse, a test function, and to be honest, a very early-stage development. It’s based on Telltale Inspector and Telltale Tool Lib.

The Prop Editor, with a few fixes and improvements, was designed to make the main goal of the Prop Editor within TTG Tools much easier. It is primarily focused on text editing inside Prop files, especially files such as feed.prop and choice.prop. The entire tool is centered around that purpose and also includes some bug fixes.

If the user intends to perform more advanced or extreme modifications, it is recommended to use Telltale Inspector, which is the original tool. TTG Tools and the Prop Editor are basically intended for editing the text contained within these Prop files.