### PR TITLE
Bump version to 1.15.6 and update changelog entries

### DIFF
--- a/master/About.resx
+++ b/master/About.resx
@@ -146,7 +146,11 @@ Maybe some games doesn't work.
 ===
 [Version history]
 
-v.1.15.4 (13.02.2026)
+v.1.15.6 (16.02.2026)
++ Archive Packer and Font Editor:
+Added support for The Walking Dead Season One on PS Vita
+
+v.1.15.5 (13.02.2026)
 + Archive Packer
 Lua encryption has been fixed when a .lenc file is present during the building of a ttarch.
 + TTG Tools:

--- a/master/Properties/AssemblyInfo.cs
+++ b/master/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.15.5.0")]
-[assembly: AssemblyFileVersion("1.15.5.0")]
+[assembly: AssemblyVersion("1.15.6.0")]
+[assembly: AssemblyFileVersion("1.15.6.0")]
 [assembly: NeutralResourcesLanguage("en")]


### PR DESCRIPTION
[Bump version to 1.15.6 and update changelog entries](https://github.com/HeitorSpectre/TTG-Tools/pull/60/commits/ebad8b86966cafc954800a13c84626eccf3d16b9)