### PR TITLE
Add Nintendo Switch-specific text encoding mode for TWD (.prop/.landb)

### DIFF
--- a/master/AutoDePackerSettings.Designer.cs
+++ b/master/AutoDePackerSettings.Designer.cs
@@ -48,6 +48,7 @@
             this.cbIgnoreEmptyStrings = new System.Windows.Forms.CheckBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.rbNewBttF = new System.Windows.Forms.RadioButton();
+            this.rbTwdNintendoSwitch = new System.Windows.Forms.RadioButton();
             this.rbNonNormalUnicode2 = new System.Windows.Forms.RadioButton();
             this.rbNormalUnicode = new System.Windows.Forms.RadioButton();
             this.groupBox3.SuspendLayout();
@@ -172,7 +173,7 @@
             // 
             // textBoxOutputFolder
             // 
-            this.textBoxOutputFolder.Location = new System.Drawing.Point(11, 244);
+            this.textBoxOutputFolder.Location = new System.Drawing.Point(11, 261);
             this.textBoxOutputFolder.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.textBoxOutputFolder.Name = "textBoxOutputFolder";
             this.textBoxOutputFolder.ReadOnly = true;
@@ -181,7 +182,7 @@
             // 
             // textBoxInputFolder
             // 
-            this.textBoxInputFolder.Location = new System.Drawing.Point(11, 215);
+            this.textBoxInputFolder.Location = new System.Drawing.Point(11, 232);
             this.textBoxInputFolder.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.textBoxInputFolder.Name = "textBoxInputFolder";
             this.textBoxInputFolder.ReadOnly = true;
@@ -190,7 +191,7 @@
             // 
             // buttonOutputFolder
             // 
-            this.buttonOutputFolder.Location = new System.Drawing.Point(335, 242);
+            this.buttonOutputFolder.Location = new System.Drawing.Point(335, 259);
             this.buttonOutputFolder.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonOutputFolder.Name = "buttonOutputFolder";
             this.buttonOutputFolder.Size = new System.Drawing.Size(90, 23);
@@ -201,7 +202,7 @@
             // 
             // buttonInputFolder
             // 
-            this.buttonInputFolder.Location = new System.Drawing.Point(335, 213);
+            this.buttonInputFolder.Location = new System.Drawing.Point(335, 230);
             this.buttonInputFolder.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonInputFolder.Name = "buttonInputFolder";
             this.buttonInputFolder.Size = new System.Drawing.Size(90, 23);
@@ -212,7 +213,7 @@
             // 
             // okBtn
             // 
-            this.okBtn.Location = new System.Drawing.Point(216, 348);
+            this.okBtn.Location = new System.Drawing.Point(216, 365);
             this.okBtn.Name = "okBtn";
             this.okBtn.Size = new System.Drawing.Size(75, 23);
             this.okBtn.TabIndex = 26;
@@ -222,7 +223,7 @@
             // 
             // cancelBtn
             // 
-            this.cancelBtn.Location = new System.Drawing.Point(317, 348);
+            this.cancelBtn.Location = new System.Drawing.Point(317, 365);
             this.cancelBtn.Name = "cancelBtn";
             this.cancelBtn.Size = new System.Drawing.Size(75, 23);
             this.cancelBtn.TabIndex = 27;
@@ -233,7 +234,7 @@
             // checkBoxChangeLangFlags
             // 
             this.checkBoxChangeLangFlags.AutoSize = true;
-            this.checkBoxChangeLangFlags.Location = new System.Drawing.Point(276, 310);
+            this.checkBoxChangeLangFlags.Location = new System.Drawing.Point(276, 327);
             this.checkBoxChangeLangFlags.Name = "checkBoxChangeLangFlags";
             this.checkBoxChangeLangFlags.Size = new System.Drawing.Size(135, 17);
             this.checkBoxChangeLangFlags.TabIndex = 28;
@@ -243,7 +244,7 @@
             // cbIgnoreEmptyStrings
             // 
             this.cbIgnoreEmptyStrings.AutoSize = true;
-            this.cbIgnoreEmptyStrings.Location = new System.Drawing.Point(11, 331);
+            this.cbIgnoreEmptyStrings.Location = new System.Drawing.Point(11, 348);
             this.cbIgnoreEmptyStrings.Name = "cbIgnoreEmptyStrings";
             this.cbIgnoreEmptyStrings.Size = new System.Drawing.Size(120, 17);
             this.cbIgnoreEmptyStrings.TabIndex = 29;
@@ -252,6 +253,7 @@
             // 
             // groupBox2
             // 
+            this.groupBox2.Controls.Add(this.rbTwdNintendoSwitch);
             this.groupBox2.Controls.Add(this.rbNewBttF);
             this.groupBox2.Controls.Add(this.rbNonNormalUnicode2);
             this.groupBox2.Controls.Add(this.rbNormalUnicode);
@@ -259,7 +261,7 @@
             this.groupBox2.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox2.Size = new System.Drawing.Size(354, 97);
+            this.groupBox2.Size = new System.Drawing.Size(354, 114);
             this.groupBox2.TabIndex = 30;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Coding for new games (From \"Tales From the Borderlands\" game)";
@@ -274,6 +276,18 @@
             this.rbNewBttF.TabStop = true;
             this.rbNewBttF.Text = "ASCII support for Back to the Future Xbox360 and PS4 versions";
             this.rbNewBttF.UseVisualStyleBackColor = true;
+            // 
+            // 
+            // rbTwdNintendoSwitch
+            // 
+            this.rbTwdNintendoSwitch.AutoSize = true;
+            this.rbTwdNintendoSwitch.Location = new System.Drawing.Point(5, 88);
+            this.rbTwdNintendoSwitch.Name = "rbTwdNintendoSwitch";
+            this.rbTwdNintendoSwitch.Size = new System.Drawing.Size(251, 17);
+            this.rbTwdNintendoSwitch.TabIndex = 4;
+            this.rbTwdNintendoSwitch.TabStop = true;
+            this.rbTwdNintendoSwitch.Text = "Support for The Walking Dead Nintendo Switch";
+            this.rbTwdNintendoSwitch.UseVisualStyleBackColor = true;
             // 
             // rbNonNormalUnicode2
             // 
@@ -304,7 +318,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(433, 388);
+            this.ClientSize = new System.Drawing.Size(433, 405);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.cbIgnoreEmptyStrings);
             this.Controls.Add(this.checkBoxChangeLangFlags);
@@ -356,6 +370,7 @@
         private System.Windows.Forms.CheckBox cbIgnoreEmptyStrings;
         private System.Windows.Forms.GroupBox groupBox2;
         private System.Windows.Forms.RadioButton rbNewBttF;
+        private System.Windows.Forms.RadioButton rbTwdNintendoSwitch;
         private System.Windows.Forms.RadioButton rbNonNormalUnicode2;
         private System.Windows.Forms.RadioButton rbNormalUnicode;
     }

--- a/master/AutoDePackerSettings.cs
+++ b/master/AutoDePackerSettings.cs
@@ -48,6 +48,8 @@ namespace TTG_Tools
                     break;
             }
 
+            rbTwdNintendoSwitch.Checked = MainMenu.settings.supportTwdNintendoSwitch;
+
             checkBoxSortStrings.Checked = MainMenu.settings.sortSameString;
             clearMessagesCB.Checked = MainMenu.settings.clearMessages;
             checkBoxD3DTX_after_import.Checked = MainMenu.settings.deleteD3DTXafterImport;
@@ -77,6 +79,8 @@ namespace TTG_Tools
             if (rbNormalUnicode.Checked) MainMenu.settings.unicodeSettings = 0;
             else if (rbNonNormalUnicode2.Checked) MainMenu.settings.unicodeSettings = 1;
             else MainMenu.settings.unicodeSettings = 2;
+
+            MainMenu.settings.supportTwdNintendoSwitch = rbTwdNintendoSwitch.Checked;
 
             if (tsvFilesRB.Checked)
             {

--- a/master/AutoPacker.cs
+++ b/master/AutoPacker.cs
@@ -95,7 +95,7 @@ namespace TTG_Tools
 
             EncVersion = comboBox2.SelectedIndex != 1 ? 2 : 7;
 
-            string versionOfGame = " ";
+            string versionOfGame = MainMenu.gamelist[comboBox1.SelectedIndex].gamename;
             numKey = comboBox1.SelectedIndex;
             selected_index = comboBox2.SelectedIndex;
             byte[] encKey = MainMenu.settings.customKey ? Methods.stringToKey(MainMenu.settings.encCustomKey) : MainMenu.gamelist[numKey].key;
@@ -128,7 +128,7 @@ namespace TTG_Tools
         {
             if (MainMenu.settings.clearMessages) listBox1.Items.Clear();
 
-            string versionOfGame = " ";
+            string versionOfGame = MainMenu.gamelist[comboBox1.SelectedIndex].gamename;
             numKey = comboBox1.SelectedIndex;
             selected_index = comboBox2.SelectedIndex;
 
@@ -399,4 +399,4 @@ namespace TTG_Tools
         {
         }
     }
-}
+}

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -303,9 +303,9 @@ namespace TTG_Tools
             FileStream fs = new FileStream(destFilePath, FileMode.CreateNew);
             BinaryWriter bw = new BinaryWriter(fs);
 
-            bool skipAnsiForSeasonStats = Methods.IsSeasonStatsTextProp(inputFile.Name);
+            bool forceAnsiForSeasonStats = Methods.IsSeasonStatsTextProp(inputFile.Name);
             bool previousForceAnsiState = Methods.GetForceAnsiForCurrentOperation();
-            if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(false);
+            if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(true);
 
             try
             {
@@ -448,7 +448,7 @@ namespace TTG_Tools
                 fs.Close();
                 br.Close();
                 ms.Close();
-                if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
+                if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
                 ReportForWork("File " + DestinationFile.Name + " imported in " + inputFile.Name + ".");
             }
             catch
@@ -458,7 +458,7 @@ namespace TTG_Tools
                 if (bw != null) bw.Close();
                 if (fs != null) fs.Close();
 
-                if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
+                if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
                 string errorMsg = "Something wrong with file " + inputFile.Name;
                 failedList.Add(inputFile.Name);
                 ReportForWork(errorMsg);
@@ -477,9 +477,9 @@ namespace TTG_Tools
             FileStream fsw = new FileStream(fullDestPath, FileMode.CreateNew);
             StreamWriter sw = new StreamWriter(fsw);
 
-            bool skipAnsiForSeasonStats = Methods.IsSeasonStatsTextProp(inputFile.Name);
+            bool forceAnsiForSeasonStats = Methods.IsSeasonStatsTextProp(inputFile.Name);
             bool previousForceAnsiState = Methods.GetForceAnsiForCurrentOperation();
-            if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(false);
+            if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(true);
 
             try
             {
@@ -557,7 +557,7 @@ namespace TTG_Tools
                 fs.Close();
                 sw.Close();
                 fsw.Close();
-                if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
+                if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
             }
             catch
             {
@@ -565,7 +565,7 @@ namespace TTG_Tools
                 if (fs != null) fs.Close();
                 if (sw != null) sw.Close();
                 if (fsw != null) fsw.Close();
-                if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
+                if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
                 ReportForWork("Something wrong with file " + inputFile.Name);
             }
         }

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -33,6 +33,9 @@ namespace TTG_Tools
             bool FullEncrypt = param[7] == "True";
             bool isNewEngine = param[8] == "True";
             byte[] encKey = Methods.stringToKey(param[9]);
+            bool useTwdNintendoSwitchAnsi = Methods.ShouldUseTwdNintendoSwitchAnsi(versionOfGame);
+
+            Methods.SetForceAnsiForCurrentOperation(useTwdNintendoSwitchAnsi);
 
             bool[] show = { false, false, false, false, false, false, false };
 
@@ -264,6 +267,8 @@ namespace TTG_Tools
             }
             finally
             {
+                Methods.SetForceAnsiForCurrentOperation(false);
+
                 // RESTAURAR: Garante que o caminho original volte ao normal, mesmo se der erro
                 MainMenu.settings.pathForOutputFolder = originalGlobalOutputPath;
             }
@@ -548,6 +553,9 @@ namespace TTG_Tools
             string versionOfGame = param[2];
             byte[] key = Methods.stringToKey(param[3]);
             int version = Convert.ToInt32(param[4]);
+            bool useTwdNintendoSwitchAnsi = Methods.ShouldUseTwdNintendoSwitchAnsi(versionOfGame);
+
+            Methods.SetForceAnsiForCurrentOperation(useTwdNintendoSwitchAnsi);
 
             // Salvar o caminho original para restaurar depois
             string originalGlobalOutputPath = MainMenu.settings.pathForOutputFolder;
@@ -679,6 +687,8 @@ namespace TTG_Tools
             }
             finally
             {
+                Methods.SetForceAnsiForCurrentOperation(false);
+
                 // Restaurar configuração original
                 MainMenu.settings.pathForOutputFolder = originalGlobalOutputPath;
             }

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -303,16 +303,15 @@ namespace TTG_Tools
             FileStream fs = new FileStream(destFilePath, FileMode.CreateNew);
             BinaryWriter bw = new BinaryWriter(fs);
 
-            bool forceAnsiForSeasonStats = Methods.IsSeasonStatsTextProp(inputFile.Name);
+            bool forceAnsiForCheckpointProp = Methods.IsCheckpointPropAnsiException(inputFile.Name);
             bool previousForceAnsiState = Methods.GetForceAnsiForCurrentOperation();
-            if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(true);
+            if (forceAnsiForCheckpointProp) Methods.SetForceAnsiForCurrentOperation(true);
 
             try
             {
                 byte[] header = br.ReadBytes(4);
                 bw.Write(header);
-                bool useUtf8ForReinsert = MainMenu.settings.supportTwdNintendoSwitch && !forceAnsiForSeasonStats;
-                if (!useUtf8ForReinsert) useUtf8ForReinsert = Encoding.ASCII.GetString(header) == "6VSM";
+                bool useUtf8ForReinsert = Methods.ShouldUseUtf8ForPropReinsert(inputFile.Name, Encoding.ASCII.GetString(header) == "6VSM");
                 if ((Encoding.ASCII.GetString(header) == "5VSM") || (Encoding.ASCII.GetString(header) == "6VSM"))
                 {
                     blHeadSize = br.ReadInt32();
@@ -450,7 +449,7 @@ namespace TTG_Tools
                 fs.Close();
                 br.Close();
                 ms.Close();
-                if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
+                if (forceAnsiForCheckpointProp) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
                 ReportForWork("File " + DestinationFile.Name + " imported in " + inputFile.Name + ".");
             }
             catch
@@ -460,7 +459,7 @@ namespace TTG_Tools
                 if (bw != null) bw.Close();
                 if (fs != null) fs.Close();
 
-                if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
+                if (forceAnsiForCheckpointProp) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
                 string errorMsg = "Something wrong with file " + inputFile.Name;
                 failedList.Add(inputFile.Name);
                 ReportForWork(errorMsg);
@@ -479,9 +478,9 @@ namespace TTG_Tools
             FileStream fsw = new FileStream(fullDestPath, FileMode.CreateNew);
             StreamWriter sw = new StreamWriter(fsw);
 
-            bool forceAnsiForSeasonStats = Methods.IsSeasonStatsTextProp(inputFile.Name);
+            bool forceAnsiForCheckpointProp = Methods.IsCheckpointPropAnsiException(inputFile.Name);
             bool previousForceAnsiState = Methods.GetForceAnsiForCurrentOperation();
-            if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(true);
+            if (forceAnsiForCheckpointProp) Methods.SetForceAnsiForCurrentOperation(true);
 
             try
             {
@@ -559,7 +558,7 @@ namespace TTG_Tools
                 fs.Close();
                 sw.Close();
                 fsw.Close();
-                if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
+                if (forceAnsiForCheckpointProp) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
             }
             catch
             {
@@ -567,7 +566,7 @@ namespace TTG_Tools
                 if (fs != null) fs.Close();
                 if (sw != null) sw.Close();
                 if (fsw != null) fsw.Close();
-                if (forceAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
+                if (forceAnsiForCheckpointProp) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
                 ReportForWork("Something wrong with file " + inputFile.Name);
             }
         }

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -396,7 +396,10 @@ namespace TTG_Tools
                         bl = br.ReadBytes(blLen);
                         blockSize += 4;
                         blHeadSize += 4;
-                        bl = Methods.EncodeGameText(strs[c], useUtf8ForReinsert);
+                        bool useUtf8ForCurrentString = useUtf8ForReinsert
+                            && !Methods.ShouldForceAnsiForSeasonStatsPropLine(inputFile.Name, strs[c]);
+
+                        bl = Methods.EncodeGameText(strs[c], useUtf8ForCurrentString);
                         blLen = bl.Length;
                         bw.Write(blLen);
                         bw.Write(bl);
@@ -428,7 +431,10 @@ namespace TTG_Tools
                         {
                             blLen = br.ReadInt32();
                             bl = br.ReadBytes(blLen);
-                            bl = Methods.EncodeGameText(strs[c], useUtf8ForReinsert);
+                            bool useUtf8ForCurrentString = useUtf8ForReinsert
+                                && !Methods.ShouldForceAnsiForSeasonStatsPropLine(inputFile.Name, strs[c]);
+
+                            bl = Methods.EncodeGameText(strs[c], useUtf8ForCurrentString);
                             blLen = bl.Length;
                             bw.Write(blLen);
                             bw.Write(bl);

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -311,6 +311,8 @@ namespace TTG_Tools
             {
                 byte[] header = br.ReadBytes(4);
                 bw.Write(header);
+                bool useUtf8ForReinsert = MainMenu.settings.supportTwdNintendoSwitch && !forceAnsiForSeasonStats;
+                if (!useUtf8ForReinsert) useUtf8ForReinsert = Encoding.ASCII.GetString(header) == "6VSM";
                 if ((Encoding.ASCII.GetString(header) == "5VSM") || (Encoding.ASCII.GetString(header) == "6VSM"))
                 {
                     blHeadSize = br.ReadInt32();
@@ -395,7 +397,7 @@ namespace TTG_Tools
                         bl = br.ReadBytes(blLen);
                         blockSize += 4;
                         blHeadSize += 4;
-                        bl = Methods.EncodeGameText(strs[c], Encoding.ASCII.GetString(header) == "6VSM");
+                        bl = Methods.EncodeGameText(strs[c], useUtf8ForReinsert);
                         blLen = bl.Length;
                         bw.Write(blLen);
                         bw.Write(bl);
@@ -427,7 +429,7 @@ namespace TTG_Tools
                         {
                             blLen = br.ReadInt32();
                             bl = br.ReadBytes(blLen);
-                            bl = Methods.EncodeGameText(strs[c], Encoding.ASCII.GetString(header) == "6VSM");
+                            bl = Methods.EncodeGameText(strs[c], useUtf8ForReinsert);
                             blLen = bl.Length;
                             bw.Write(blLen);
                             bw.Write(bl);

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -373,7 +373,7 @@ namespace TTG_Tools
                         bl = br.ReadBytes(blLen);
                         blockSize += 4;
                         blHeadSize += 4;
-                        bl = Encoding.ASCII.GetString(header) == "6VSM" ? Encoding.UTF8.GetBytes(strs[c]) : Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(strs[c]);
+                        bl = Methods.EncodeGameText(strs[c], Encoding.ASCII.GetString(header) == "6VSM");
                         blLen = bl.Length;
                         bw.Write(blLen);
                         bw.Write(bl);
@@ -405,7 +405,7 @@ namespace TTG_Tools
                         {
                             blLen = br.ReadInt32();
                             bl = br.ReadBytes(blLen);
-                            bl = Encoding.ASCII.GetString(header) == "6VSM" ? Encoding.UTF8.GetBytes(strs[c]) : Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(strs[c]);
+                            bl = Methods.EncodeGameText(strs[c], Encoding.ASCII.GetString(header) == "6VSM");
                             blLen = bl.Length;
                             bw.Write(blLen);
                             bw.Write(bl);
@@ -493,8 +493,7 @@ namespace TTG_Tools
                         if (Encoding.ASCII.GetString(header) == "ERTM") one1 = br.ReadInt32();
                         int len = br.ReadInt32();
                         bValue = br.ReadBytes(len);
-                        strs[i] = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(bValue);
-                        if (Encoding.ASCII.GetString(header) == "6VSM") strs[i] = Encoding.UTF8.GetString(bValue);
+                        strs[i] = Methods.DecodeGameText(bValue, Encoding.ASCII.GetString(header) == "6VSM");
                         sw.WriteLine(Convert.ToString(c_str) + ")");
                         sw.WriteLine(strs[i]);
                         c_str++;
@@ -517,8 +516,7 @@ namespace TTG_Tools
                         {
                             int len = br.ReadInt32();
                             bValue = br.ReadBytes(len);
-                            strs[i][j] = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(bValue);
-                            if (Encoding.ASCII.GetString(header) == "6VSM") strs[i][j] = Encoding.UTF8.GetString(bValue);
+                            strs[i][j] = Methods.DecodeGameText(bValue, Encoding.ASCII.GetString(header) == "6VSM");
                             sw.WriteLine(Convert.ToString(c_str) + ")");
                             sw.WriteLine(strs[i][j]);
                             c_str++;

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -290,6 +290,11 @@ namespace TTG_Tools
             if (File.Exists(destFilePath)) File.Delete(destFilePath);
             FileStream fs = new FileStream(destFilePath, FileMode.CreateNew);
             BinaryWriter bw = new BinaryWriter(fs);
+
+            bool skipAnsiForSeasonStats = Methods.IsSeasonStatsTextProp(inputFile.Name);
+            bool previousForceAnsiState = Methods.GetForceAnsiForCurrentOperation();
+            if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(false);
+
             try
             {
                 byte[] header = br.ReadBytes(4);
@@ -431,6 +436,7 @@ namespace TTG_Tools
                 fs.Close();
                 br.Close();
                 ms.Close();
+                if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
                 ReportForWork("File " + DestinationFile.Name + " imported in " + inputFile.Name + ".");
             }
             catch
@@ -440,6 +446,7 @@ namespace TTG_Tools
                 if (bw != null) bw.Close();
                 if (fs != null) fs.Close();
 
+                if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
                 string errorMsg = "Something wrong with file " + inputFile.Name;
                 failedList.Add(inputFile.Name);
                 ReportForWork(errorMsg);
@@ -457,6 +464,11 @@ namespace TTG_Tools
             if (File.Exists(fullDestPath)) File.Delete(fullDestPath);
             FileStream fsw = new FileStream(fullDestPath, FileMode.CreateNew);
             StreamWriter sw = new StreamWriter(fsw);
+
+            bool skipAnsiForSeasonStats = Methods.IsSeasonStatsTextProp(inputFile.Name);
+            bool previousForceAnsiState = Methods.GetForceAnsiForCurrentOperation();
+            if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(false);
+
             try
             {
                 //Read for checkpoint_text.prop and statsInfo_text.prop files
@@ -533,6 +545,7 @@ namespace TTG_Tools
                 fs.Close();
                 sw.Close();
                 fsw.Close();
+                if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
             }
             catch
             {
@@ -540,6 +553,7 @@ namespace TTG_Tools
                 if (fs != null) fs.Close();
                 if (sw != null) sw.Close();
                 if (fsw != null) fsw.Close();
+                if (skipAnsiForSeasonStats) Methods.SetForceAnsiForCurrentOperation(previousForceAnsiState);
                 ReportForWork("Something wrong with file " + inputFile.Name);
             }
         }

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -125,7 +125,19 @@ namespace TTG_Tools
                                                 show[0] = true;
                                                 break;
                                             case ".landb":
-                                                result = Texts.LandbWorker.DoWork(inputFiles[i].FullName, fileDestination[j].FullName, false, encKey, version);
+                                                bool skipAnsiForSpecificLandbImport = Methods.IsLandbExcludedFromTwdSwitchAnsi(inputFiles[i].Name);
+                                                bool previousLandbImportForceAnsiState = Methods.GetForceAnsiForCurrentOperation();
+                                                if (skipAnsiForSpecificLandbImport) Methods.SetForceAnsiForCurrentOperation(false);
+
+                                                try
+                                                {
+                                                    result = Texts.LandbWorker.DoWork(inputFiles[i].FullName, fileDestination[j].FullName, false, encKey, version);
+                                                }
+                                                finally
+                                                {
+                                                    if (skipAnsiForSpecificLandbImport) Methods.SetForceAnsiForCurrentOperation(previousLandbImportForceAnsiState);
+                                                }
+
                                                 ReportForWork(result);
                                                 emptyFiles = false;
                                                 show[1] = true;
@@ -638,7 +650,19 @@ namespace TTG_Tools
 
                                     case ".landb":
                                         // Usa config global
-                                        message = Texts.LandbWorker.DoWork(inputFiles[i].FullName, "", true, key, version);
+                                        bool skipAnsiForSpecificLandbExport = Methods.IsLandbExcludedFromTwdSwitchAnsi(inputFiles[i].Name);
+                                        bool previousLandbExportForceAnsiState = Methods.GetForceAnsiForCurrentOperation();
+                                        if (skipAnsiForSpecificLandbExport) Methods.SetForceAnsiForCurrentOperation(false);
+
+                                        try
+                                        {
+                                            message = Texts.LandbWorker.DoWork(inputFiles[i].FullName, "", true, key, version);
+                                        }
+                                        finally
+                                        {
+                                            if (skipAnsiForSpecificLandbExport) Methods.SetForceAnsiForCurrentOperation(previousLandbExportForceAnsiState);
+                                        }
+
                                         ReportForWork(message);
                                         extractedFormat[2] = 2;
                                         break;

--- a/master/FormSettings.Designer.cs
+++ b/master/FormSettings.Designer.cs
@@ -37,6 +37,7 @@
             this.buttonApplyAndExitSettings = new System.Windows.Forms.Button();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.rbNewBttF = new System.Windows.Forms.RadioButton();
+            this.rbTwdNintendoSwitch = new System.Windows.Forms.RadioButton();
             this.rbNonNormalUnicode2 = new System.Windows.Forms.RadioButton();
             this.rbNormalUnicode = new System.Windows.Forms.RadioButton();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
@@ -86,7 +87,7 @@
             // 
             // buttonSaveSettings
             // 
-            this.buttonSaveSettings.Location = new System.Drawing.Point(180, 312);
+            this.buttonSaveSettings.Location = new System.Drawing.Point(180, 329);
             this.buttonSaveSettings.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonSaveSettings.Name = "buttonSaveSettings";
             this.buttonSaveSettings.Size = new System.Drawing.Size(136, 23);
@@ -97,7 +98,7 @@
             // 
             // buttonExitSettingsForm
             // 
-            this.buttonExitSettingsForm.Location = new System.Drawing.Point(333, 312);
+            this.buttonExitSettingsForm.Location = new System.Drawing.Point(333, 329);
             this.buttonExitSettingsForm.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonExitSettingsForm.Name = "buttonExitSettingsForm";
             this.buttonExitSettingsForm.Size = new System.Drawing.Size(88, 23);
@@ -108,7 +109,7 @@
             // 
             // buttonApplyAndExitSettings
             // 
-            this.buttonApplyAndExitSettings.Location = new System.Drawing.Point(36, 312);
+            this.buttonApplyAndExitSettings.Location = new System.Drawing.Point(36, 329);
             this.buttonApplyAndExitSettings.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.buttonApplyAndExitSettings.Name = "buttonApplyAndExitSettings";
             this.buttonApplyAndExitSettings.Size = new System.Drawing.Size(136, 23);
@@ -119,6 +120,7 @@
             // 
             // groupBox2
             // 
+            this.groupBox2.Controls.Add(this.rbTwdNintendoSwitch);
             this.groupBox2.Controls.Add(this.rbNewBttF);
             this.groupBox2.Controls.Add(this.rbNonNormalUnicode2);
             this.groupBox2.Controls.Add(this.rbNormalUnicode);
@@ -126,7 +128,7 @@
             this.groupBox2.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox2.Size = new System.Drawing.Size(354, 97);
+            this.groupBox2.Size = new System.Drawing.Size(354, 114);
             this.groupBox2.TabIndex = 13;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Coding for new games (From \"Tales From the Borderlands\" game)";
@@ -141,6 +143,18 @@
             this.rbNewBttF.TabStop = true;
             this.rbNewBttF.Text = "ASCII support for Back to the Future Xbox360 and PS4 versions";
             this.rbNewBttF.UseVisualStyleBackColor = true;
+            // 
+            // 
+            // rbTwdNintendoSwitch
+            // 
+            this.rbTwdNintendoSwitch.AutoSize = true;
+            this.rbTwdNintendoSwitch.Location = new System.Drawing.Point(5, 88);
+            this.rbTwdNintendoSwitch.Name = "rbTwdNintendoSwitch";
+            this.rbTwdNintendoSwitch.Size = new System.Drawing.Size(251, 17);
+            this.rbTwdNintendoSwitch.TabIndex = 4;
+            this.rbTwdNintendoSwitch.TabStop = true;
+            this.rbTwdNintendoSwitch.Text = "Support for The Walking Dead Nintendo Switch";
+            this.rbTwdNintendoSwitch.UseVisualStyleBackColor = true;
             // 
             // rbNonNormalUnicode2
             // 
@@ -216,7 +230,7 @@
             this.groupBox1.Controls.Add(this.textBoxInputFolder);
             this.groupBox1.Controls.Add(this.buttonInputFolder);
             this.groupBox1.Controls.Add(this.buttonOutputFolder);
-            this.groupBox1.Location = new System.Drawing.Point(19, 199);
+            this.groupBox1.Location = new System.Drawing.Point(19, 216);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(427, 100);
             this.groupBox1.TabIndex = 30;
@@ -247,7 +261,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(475, 368);
+            this.ClientSize = new System.Drawing.Size(475, 385);
             this.Controls.Add(this.languageComboBox);
             this.Controls.Add(this.checkLanguage);
             this.Controls.Add(this.groupBox1);
@@ -288,6 +302,7 @@
         private System.Windows.Forms.ToolTip toolTip3;
         private System.Windows.Forms.RadioButton rbNonNormalUnicode2;
         private System.Windows.Forms.RadioButton rbNewBttF;
+        private System.Windows.Forms.RadioButton rbTwdNintendoSwitch;
         private System.Windows.Forms.Button buttonOutputFolder;
         private System.Windows.Forms.Button buttonInputFolder;
         private System.Windows.Forms.TextBox textBoxInputFolder;

--- a/master/FormSettings.cs
+++ b/master/FormSettings.cs
@@ -44,6 +44,8 @@ namespace TTG_Tools
             else if (rbNonNormalUnicode2.Checked == true) MainMenu.settings.unicodeSettings = 1;
             else MainMenu.settings.unicodeSettings = 2;
 
+            MainMenu.settings.supportTwdNintendoSwitch = rbTwdNintendoSwitch.Checked;
+
             MainMenu.settings.languageIndex = -1;
             if (checkLanguage.Checked)
             {
@@ -267,6 +269,8 @@ namespace TTG_Tools
                     rbNormalUnicode.Checked = true;
                     break;
             }
+
+            rbTwdNintendoSwitch.Checked = MainMenu.settings.supportTwdNintendoSwitch;
         }
 
         private void buttonInputFolder_Click(object sender, EventArgs e)

--- a/master/MainMenu.cs
+++ b/master/MainMenu.cs
@@ -10,7 +10,7 @@ namespace TTG_Tools
 {
     public partial class MainMenu : Form
     {
-        public static Settings settings = new Settings("", "", 1251, false, false, false, true, false, 0, false, false, false, false, false, false, 0, 0, "", "", "", false, false, false, false, 0, 0, false, false, false, false, false, false, false, false, -1);
+        public static Settings settings = new Settings("", "", 1251, false, false, false, true, false, 0, false, false, false, false, false, false, 0, 0, "", "", "", false, false, false, false, 0, 0, false, false, false, false, false, false, false, false, -1, false);
 
         [DllImport("kernel32.dll")]
         public static extern void SetProcessWorkingSetSize(IntPtr hWnd, int i, int j);
@@ -353,4 +353,4 @@ namespace TTG_Tools
             }
         }
     }
-}
+}

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -116,10 +116,33 @@ namespace TTG_Tools
             return false;
         }
 
+        public static bool ContainsJapaneseCharacters(string text)
+        {
+            if (String.IsNullOrEmpty(text)) return false;
+
+            for (int i = 0; i < text.Length; i++)
+            {
+                char c = text[i];
+
+                // Hiragana, Katakana, CJK Unified Ideographs, Halfwidth Katakana
+                if ((c >= '\u3040' && c <= '\u309F')
+                    || (c >= '\u30A0' && c <= '\u30FF')
+                    || (c >= '\u4E00' && c <= '\u9FFF')
+                    || (c >= '\uFF66' && c <= '\uFF9D'))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
         public static bool ShouldForceUtf8ForLandbString(string fileName, string text, bool openingCreditsReplacementMode)
         {
             if (!MainMenu.settings.supportTwdNintendoSwitch) return false;
             if (String.IsNullOrEmpty(text)) return false;
+
+            if (ContainsJapaneseCharacters(text)) return true;
 
             string safeName = Path.GetFileName(fileName ?? "");
 

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -24,12 +24,24 @@ namespace TTG_Tools
             return _forceAnsiForCurrentOperation;
         }
 
-        public static bool IsSeasonStatsTextProp(string fileName)
+        public static bool IsCheckpointPropAnsiException(string fileName)
         {
             if (!MainMenu.settings.supportTwdNintendoSwitch) return false;
 
             string safeName = Path.GetFileName(fileName ?? "");
             return safeName.Equals("checkpoint_text.prop", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool ShouldUseUtf8ForPropReinsert(string fileName, bool headerIs6VSM)
+        {
+            if (MainMenu.settings.supportTwdNintendoSwitch)
+            {
+                // New requested strategy for Switch mode:
+                // all PROP reinsertion in UTF-8, except checkpoint_text.prop in ANSI.
+                return !IsCheckpointPropAnsiException(fileName);
+            }
+
+            return headerIs6VSM;
         }
 
         public static bool IsLandbExcludedFromTwdSwitchAnsi(string fileName)

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -12,6 +12,22 @@ namespace TTG_Tools
 {
     class Methods
     {
+        private static bool _forceAnsiForCurrentOperation = false;
+
+        public static void SetForceAnsiForCurrentOperation(bool enabled)
+        {
+            _forceAnsiForCurrentOperation = enabled;
+        }
+
+        public static bool ShouldUseTwdNintendoSwitchAnsi(string versionOfGame)
+        {
+            if (!MainMenu.settings.supportTwdNintendoSwitch) return false;
+            if (String.IsNullOrEmpty(versionOfGame)) return false;
+
+            return versionOfGame == "The Walking Dead: Season One"
+                || versionOfGame == "The Walking Dead: The Telltale Definitive Series";
+        }
+
         public static bool IsNumeric(string str)
         {
             try
@@ -81,7 +97,7 @@ namespace TTG_Tools
 
         public static string DecodeGameText(byte[] bytes, bool useUtf8)
         {
-            if (useUtf8)
+            if (useUtf8 && !_forceAnsiForCurrentOperation)
             {
                 return Encoding.UTF8.GetString(bytes);
             }
@@ -97,7 +113,7 @@ namespace TTG_Tools
 
         public static byte[] EncodeGameText(string text, bool useUtf8)
         {
-            if (useUtf8)
+            if (useUtf8 && !_forceAnsiForCurrentOperation)
             {
                 return Encoding.UTF8.GetBytes(text);
             }

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -79,6 +79,38 @@ namespace TTG_Tools
             return str;
         }
 
+        public static string DecodeGameText(byte[] bytes, bool useUtf8)
+        {
+            if (useUtf8)
+            {
+                return Encoding.UTF8.GetString(bytes);
+            }
+
+            int codePage = MainMenu.settings.ASCII_N;
+            if (MainMenu.settings.supportTwdNintendoSwitch)
+            {
+                codePage = 1252;
+            }
+
+            return Encoding.GetEncoding(codePage).GetString(bytes);
+        }
+
+        public static byte[] EncodeGameText(string text, bool useUtf8)
+        {
+            if (useUtf8)
+            {
+                return Encoding.UTF8.GetBytes(text);
+            }
+
+            int codePage = MainMenu.settings.ASCII_N;
+            if (MainMenu.settings.supportTwdNintendoSwitch)
+            {
+                codePage = 1252;
+            }
+
+            return Encoding.GetEncoding(codePage).GetBytes(text);
+        }
+
         public static UInt64 pad_it(UInt64 num, UInt64 pad)
         {
             UInt64 t;

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -44,6 +44,19 @@ namespace TTG_Tools
             return headerIs6VSM;
         }
 
+        public static bool ShouldForceAnsiForSeasonStatsPropLine(string fileName, string text)
+        {
+            if (!MainMenu.settings.supportTwdNintendoSwitch) return false;
+
+            string safeName = Path.GetFileName(fileName ?? "");
+            if (!safeName.Equals("seasonStatsText.prop", StringComparison.OrdinalIgnoreCase)) return false;
+
+            return String.Equals(
+                text,
+                "Il est mort quand ils ont attaqué le drugstore.",
+                StringComparison.Ordinal);
+        }
+
         public static bool IsLandbExcludedFromTwdSwitchAnsi(string fileName)
         {
             if (!MainMenu.settings.supportTwdNintendoSwitch) return false;

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -267,7 +267,9 @@ namespace TTG_Tools
 
         public static byte[] EncodeGameText(string text, bool useUtf8)
         {
-            if (useUtf8 && !_forceAnsiForCurrentOperation)
+            // If caller explicitly requests UTF-8 for this string,
+            // always honor that to preserve non-ANSI content (e.g. kanji).
+            if (useUtf8)
             {
                 return Encoding.UTF8.GetBytes(text);
             }

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -58,13 +58,44 @@ namespace TTG_Tools
         public static string MapReplacementCharToCopyright(string text, bool enabled)
         {
             if (!enabled || text == null) return text;
-            return text.Replace('\uFFFD', '©');
+            return text.Replace('\uFFFD', '©').Replace("ï¿½", "©");
         }
 
         public static string MapCopyrightToReplacementChar(string text, bool enabled)
         {
             if (!enabled || text == null) return text;
             return text.Replace('©', '\uFFFD');
+        }
+
+        public static int GetActiveTextCodePage()
+        {
+            int codePage = MainMenu.settings.ASCII_N;
+            if (MainMenu.settings.supportTwdNintendoSwitch)
+            {
+                codePage = 1252;
+            }
+
+            return codePage;
+        }
+
+        public static bool IsTextRepresentableInActiveEncoding(string text)
+        {
+            if (text == null) return true;
+
+            Encoding enc = Encoding.GetEncoding(
+                GetActiveTextCodePage(),
+                EncoderFallback.ExceptionFallback,
+                DecoderFallback.ExceptionFallback);
+
+            try
+            {
+                enc.GetBytes(text);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
         }
 
         public static bool ShouldUseTwdNintendoSwitchAnsi(string versionOfGame)
@@ -145,11 +176,7 @@ namespace TTG_Tools
 
         public static string DecodeGameText(byte[] bytes, bool useUtf8)
         {
-            int codePage = MainMenu.settings.ASCII_N;
-            if (MainMenu.settings.supportTwdNintendoSwitch)
-            {
-                codePage = 1252;
-            }
+            int codePage = GetActiveTextCodePage();
 
             // Some files contain mixed ANSI/UTF-8 strings in the same block.
             // Try strict UTF-8 first and fall back to ANSI only when bytes are not valid UTF-8.
@@ -188,11 +215,7 @@ namespace TTG_Tools
                 return Encoding.UTF8.GetBytes(text);
             }
 
-            int codePage = MainMenu.settings.ASCII_N;
-            if (MainMenu.settings.supportTwdNintendoSwitch)
-            {
-                codePage = 1252;
-            }
+            int codePage = GetActiveTextCodePage();
 
             return Encoding.GetEncoding(codePage).GetBytes(text);
         }

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -30,6 +30,16 @@ namespace TTG_Tools
             return safeName.Equals("seasonStatsText.prop", StringComparison.OrdinalIgnoreCase);
         }
 
+        public static bool IsLandbExcludedFromTwdSwitchAnsi(string fileName)
+        {
+            string safeName = Path.GetFileName(fileName ?? "");
+
+            return safeName.Equals("tutorial_english.landb", StringComparison.OrdinalIgnoreCase)
+                || safeName.Equals("aliased_english.landb", StringComparison.OrdinalIgnoreCase)
+                || safeName.Equals("choice_notification_english.landb", StringComparison.OrdinalIgnoreCase)
+                || safeName.Equals("ui_menu_english.landb", StringComparison.OrdinalIgnoreCase);
+        }
+
         public static bool ShouldUseTwdNintendoSwitchAnsi(string versionOfGame)
         {
             if (!MainMenu.settings.supportTwdNintendoSwitch) return false;

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -176,6 +176,7 @@ namespace TTG_Tools
             }
 
             if (safeName.Equals("dairyexterior_lee_andy_english.landb", StringComparison.OrdinalIgnoreCase)
+                || safeName.Equals("dairyexterior_lee_brenda_english.landb", StringComparison.OrdinalIgnoreCase)
                 || safeName.Equals("dairyexterior_lee_lilly_english.landb", StringComparison.OrdinalIgnoreCase)
                 || safeName.Equals("env_dairyexterior_atthedairy_english.landb", StringComparison.OrdinalIgnoreCase)
                 || safeName.Equals("env_dairymeatlocker_english.landb", StringComparison.OrdinalIgnoreCase)

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -19,6 +19,17 @@ namespace TTG_Tools
             _forceAnsiForCurrentOperation = enabled;
         }
 
+        public static bool GetForceAnsiForCurrentOperation()
+        {
+            return _forceAnsiForCurrentOperation;
+        }
+
+        public static bool IsSeasonStatsTextProp(string fileName)
+        {
+            string safeName = Path.GetFileName(fileName ?? "");
+            return safeName.Equals("seasonStatsText.prop", StringComparison.OrdinalIgnoreCase);
+        }
+
         public static bool ShouldUseTwdNintendoSwitchAnsi(string versionOfGame)
         {
             if (!MainMenu.settings.supportTwdNintendoSwitch) return false;

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -26,12 +26,16 @@ namespace TTG_Tools
 
         public static bool IsSeasonStatsTextProp(string fileName)
         {
+            if (!MainMenu.settings.supportTwdNintendoSwitch) return false;
+
             string safeName = Path.GetFileName(fileName ?? "");
             return safeName.Equals("seasonStatsText.prop", StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool IsLandbExcludedFromTwdSwitchAnsi(string fileName)
         {
+            if (!MainMenu.settings.supportTwdNintendoSwitch) return false;
+
             string safeName = Path.GetFileName(fileName ?? "");
 
             return safeName.Equals("ui_menu_english.landb", StringComparison.OrdinalIgnoreCase);
@@ -39,6 +43,8 @@ namespace TTG_Tools
 
         public static bool ShouldMapOpeningCreditsReplacement(string fileName, byte[] originalFileBytes)
         {
+            if (!MainMenu.settings.supportTwdNintendoSwitch) return false;
+
             string safeName = Path.GetFileName(fileName ?? "");
 
             if (!safeName.Equals("ui_openingcredits_english.landb", StringComparison.OrdinalIgnoreCase)) return false;

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -34,10 +34,37 @@ namespace TTG_Tools
         {
             string safeName = Path.GetFileName(fileName ?? "");
 
-            return safeName.Equals("tutorial_english.landb", StringComparison.OrdinalIgnoreCase)
-                || safeName.Equals("aliased_english.landb", StringComparison.OrdinalIgnoreCase)
-                || safeName.Equals("choice_notification_english.landb", StringComparison.OrdinalIgnoreCase)
-                || safeName.Equals("ui_menu_english.landb", StringComparison.OrdinalIgnoreCase);
+            return safeName.Equals("ui_menu_english.landb", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public static bool ShouldMapOpeningCreditsReplacement(string fileName, byte[] originalFileBytes)
+        {
+            string safeName = Path.GetFileName(fileName ?? "");
+
+            if (!safeName.Equals("ui_openingcredits_english.landb", StringComparison.OrdinalIgnoreCase)) return false;
+            if (originalFileBytes == null || originalFileBytes.Length < 3) return false;
+
+            for (int i = 0; i < originalFileBytes.Length - 2; i++)
+            {
+                if ((originalFileBytes[i] == 0xEF) && (originalFileBytes[i + 1] == 0xBF) && (originalFileBytes[i + 2] == 0xBD))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public static string MapReplacementCharToCopyright(string text, bool enabled)
+        {
+            if (!enabled || text == null) return text;
+            return text.Replace('\uFFFD', '©');
+        }
+
+        public static string MapCopyrightToReplacementChar(string text, bool enabled)
+        {
+            if (!enabled || text == null) return text;
+            return text.Replace('©', '\uFFFD');
         }
 
         public static bool ShouldUseTwdNintendoSwitchAnsi(string versionOfGame)

--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -29,7 +29,7 @@ namespace TTG_Tools
             if (!MainMenu.settings.supportTwdNintendoSwitch) return false;
 
             string safeName = Path.GetFileName(fileName ?? "");
-            return safeName.Equals("seasonStatsText.prop", StringComparison.OrdinalIgnoreCase);
+            return safeName.Equals("checkpoint_text.prop", StringComparison.OrdinalIgnoreCase);
         }
 
         public static bool IsLandbExcludedFromTwdSwitchAnsi(string fileName)

--- a/master/Settings.cs
+++ b/master/Settings.cs
@@ -53,6 +53,7 @@ namespace TTG_Tools
         private bool _swizzlePS4;
         private bool _swizzleXbox360;
         private bool _swizzlePSVita;
+        private bool _supportTwdNintendoSwitch;
 
         private int _languageIndex;
 
@@ -512,6 +513,19 @@ namespace TTG_Tools
             }
         }
 
+        [XmlAttribute("supportTwdNintendoSwitch")]
+        public bool supportTwdNintendoSwitch
+        {
+            get
+            {
+                return _supportTwdNintendoSwitch;
+            }
+            set
+            {
+                _supportTwdNintendoSwitch = value;
+            }
+        }
+
         public Settings(
             string _pathForInputFolder,
             string _pathForOutputFolder,
@@ -547,7 +561,8 @@ namespace TTG_Tools
             bool _swizzlePS4,
             bool _swizzleXbox360,
             bool _swizzlePSVita,
-            int _languageIndex)
+            int _languageIndex,
+            bool _supportTwdNintendoSwitch)
         {
             this.ASCII_N = _ASCII_N;
             this.pathForInputFolder = _pathForInputFolder;
@@ -584,6 +599,7 @@ namespace TTG_Tools
             this.swizzleXbox360 = _swizzleXbox360;
             this.swizzlePSVita = _swizzlePSVita;
             this.languageIndex = _languageIndex;
+            this.supportTwdNintendoSwitch = _supportTwdNintendoSwitch;
         }
 
         public Settings()

--- a/master/Texts/LandbWorker.cs
+++ b/master/Texts/LandbWorker.cs
@@ -160,7 +160,7 @@ namespace TTG_Tools.Texts
                     landb.landbs[i].actorNameSize = br.ReadInt32();
                     tmp = br.ReadBytes(landb.landbs[i].actorNameSize);
                     landb.landbs[i].actorName = Methods.DecodeGameText(tmp, landb.isUnicode);
-                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
+                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode)
                     {
                         landb.landbs[i].actorName = Methods.isUTF8String(tmp)
                             ? Encoding.UTF8.GetString(tmp)
@@ -174,7 +174,7 @@ namespace TTG_Tools.Texts
                     landb.landbs[i].actorSpeechSize = br.ReadInt32();
                     tmp = br.ReadBytes(landb.landbs[i].actorSpeechSize);
                     landb.landbs[i].actorSpeech = Methods.DecodeGameText(tmp, landb.isUnicode);
-                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
+                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode)
                     {
                         landb.landbs[i].actorSpeech = Methods.isUTF8String(tmp)
                             ? Encoding.UTF8.GetString(tmp)
@@ -356,7 +356,7 @@ namespace TTG_Tools.Texts
                     bw.Write(landb.landbs[i].zero2);
 
                     byte[] tmpActorName = Methods.EncodeGameText(landb.landbs[i].actorName, landb.isUnicode);
-                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
+                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode)
                     {
                         bool useUtf8ForActorName = !Methods.IsTextRepresentableInActiveEncoding(landb.landbs[i].actorName)
                             || Methods.ShouldForceUtf8ForLandbString(inputFileName, landb.landbs[i].actorName, openingCreditsReplacementMode);
@@ -368,7 +368,7 @@ namespace TTG_Tools.Texts
                     landb.newLandbFileSize += 4 + landb.landbs[i].actorNameSize;
 
                     byte[] tmpActorSpeech = Methods.EncodeGameText(landb.landbs[i].actorSpeech, landb.isUnicode);
-                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
+                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode)
                     {
                         string speechText = landb.landbs[i].actorSpeech;
                         bool endsUtf8Marker = (speechText.IndexOf("(utf8)") > 0) && (speechText.IndexOf("(utf8)") == speechText.Length - 6);

--- a/master/Texts/LandbWorker.cs
+++ b/master/Texts/LandbWorker.cs
@@ -505,6 +505,7 @@ namespace TTG_Tools.Texts
             byte[] buffer = File.ReadAllBytes(InputFile);
             MemoryStream ms = new MemoryStream(buffer);
             BinaryReader br = new BinaryReader(ms);
+            bool mapOpeningCreditsReplacement = Methods.ShouldMapOpeningCreditsReplacement(fi.Name, buffer);
 
             try
             {
@@ -567,6 +568,11 @@ namespace TTG_Tools.Texts
                         txt.actorName = landbs.landbs[i].actorName;
                         txt.actorSpeechOriginal = landbs.landbs[i].actorSpeech;
                         txt.actorSpeechTranslation = landbs.landbs[i].actorSpeech;
+
+                        txt.actorName = Methods.MapReplacementCharToCopyright(txt.actorName, mapOpeningCreditsReplacement);
+                        txt.actorSpeechOriginal = Methods.MapReplacementCharToCopyright(txt.actorSpeechOriginal, mapOpeningCreditsReplacement);
+                        txt.actorSpeechTranslation = Methods.MapReplacementCharToCopyright(txt.actorSpeechTranslation, mapOpeningCreditsReplacement);
+
                         txt.flags = Encoding.ASCII.GetString(landbs.flags[i].flags);
 
                         if (((txt.actorSpeechOriginal == "") && !MainMenu.settings.ignoreEmptyStrings)
@@ -599,6 +605,18 @@ namespace TTG_Tools.Texts
                 {
                     ClassesStructs.Text.CommonTextClass txts = new CommonTextClass();
                     txts.txtList = ReadText.GetStrings(TxtFile);
+
+                    if (mapOpeningCreditsReplacement && txts.txtList != null)
+                    {
+                        for (int i = 0; i < txts.txtList.Count; i++)
+                        {
+                            ClassesStructs.Text.CommonText tmpTxt = txts.txtList[i];
+                            tmpTxt.actorName = Methods.MapCopyrightToReplacementChar(tmpTxt.actorName, true);
+                            tmpTxt.actorSpeechOriginal = Methods.MapCopyrightToReplacementChar(tmpTxt.actorSpeechOriginal, true);
+                            tmpTxt.actorSpeechTranslation = Methods.MapCopyrightToReplacementChar(tmpTxt.actorSpeechTranslation, true);
+                            txts.txtList[i] = tmpTxt;
+                        }
+                    }
 
                     /*if (txts.txtList.Count < landbs.landbCount)
                     {

--- a/master/Texts/LandbWorker.cs
+++ b/master/Texts/LandbWorker.cs
@@ -360,7 +360,7 @@ namespace TTG_Tools.Texts
                     {
                         bool useUtf8ForActorName = true;
 
-                        if (Methods.IsSeasonStatsTextProp(inputFileName))
+                        if (Methods.IsCheckpointPropAnsiException(inputFileName))
                         {
                             useUtf8ForActorName = false;
                         }
@@ -399,7 +399,7 @@ namespace TTG_Tools.Texts
                         {
                             bool useUtf8ForSpeech = true;
 
-                            if (Methods.IsSeasonStatsTextProp(inputFileName))
+                            if (Methods.IsCheckpointPropAnsiException(inputFileName))
                             {
                                 useUtf8ForSpeech = false;
                             }

--- a/master/Texts/LandbWorker.cs
+++ b/master/Texts/LandbWorker.cs
@@ -358,8 +358,18 @@ namespace TTG_Tools.Texts
                     byte[] tmpActorName = Methods.EncodeGameText(landb.landbs[i].actorName, landb.isUnicode);
                     if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode)
                     {
-                        bool useUtf8ForActorName = !Methods.IsTextRepresentableInActiveEncoding(landb.landbs[i].actorName)
-                            || Methods.ShouldForceUtf8ForLandbString(inputFileName, landb.landbs[i].actorName, openingCreditsReplacementMode);
+                        bool useUtf8ForActorName = true;
+
+                        if (Methods.IsSeasonStatsTextProp(inputFileName))
+                        {
+                            useUtf8ForActorName = false;
+                        }
+
+                        if (Methods.ShouldForceUtf8ForLandbString(inputFileName, landb.landbs[i].actorName, openingCreditsReplacementMode))
+                        {
+                            useUtf8ForActorName = true;
+                        }
+
                         tmpActorName = Methods.EncodeGameText(landb.landbs[i].actorName, useUtf8ForActorName);
                     }
                     landb.landbs[i].actorNameSize = tmpActorName.Length;
@@ -387,8 +397,18 @@ namespace TTG_Tools.Texts
                         }
                         else
                         {
-                            bool useUtf8ForSpeech = !Methods.IsTextRepresentableInActiveEncoding(speechText)
-                                || Methods.ShouldForceUtf8ForLandbString(inputFileName, speechText, openingCreditsReplacementMode);
+                            bool useUtf8ForSpeech = true;
+
+                            if (Methods.IsSeasonStatsTextProp(inputFileName))
+                            {
+                                useUtf8ForSpeech = false;
+                            }
+
+                            if (Methods.ShouldForceUtf8ForLandbString(inputFileName, speechText, openingCreditsReplacementMode))
+                            {
+                                useUtf8ForSpeech = true;
+                            }
+
                             tmpActorSpeech = Methods.EncodeGameText(speechText, useUtf8ForSpeech);
                         }
                     }

--- a/master/Texts/LandbWorker.cs
+++ b/master/Texts/LandbWorker.cs
@@ -160,7 +160,7 @@ namespace TTG_Tools.Texts
                     landb.landbs[i].actorNameSize = br.ReadInt32();
                     tmp = br.ReadBytes(landb.landbs[i].actorNameSize);
                     landb.landbs[i].actorName = Methods.DecodeGameText(tmp, landb.isUnicode);
-                    if (landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
+                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
                     {
                         landb.landbs[i].actorName = Methods.isUTF8String(tmp)
                             ? Encoding.UTF8.GetString(tmp)
@@ -174,7 +174,7 @@ namespace TTG_Tools.Texts
                     landb.landbs[i].actorSpeechSize = br.ReadInt32();
                     tmp = br.ReadBytes(landb.landbs[i].actorSpeechSize);
                     landb.landbs[i].actorSpeech = Methods.DecodeGameText(tmp, landb.isUnicode);
-                    if (landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
+                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
                     {
                         landb.landbs[i].actorSpeech = Methods.isUTF8String(tmp)
                             ? Encoding.UTF8.GetString(tmp)
@@ -356,7 +356,7 @@ namespace TTG_Tools.Texts
                     bw.Write(landb.landbs[i].zero2);
 
                     byte[] tmpActorName = Methods.EncodeGameText(landb.landbs[i].actorName, landb.isUnicode);
-                    if (landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
+                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
                     {
                         bool useUtf8ForActorName = !Methods.IsTextRepresentableInActiveEncoding(landb.landbs[i].actorName);
                         tmpActorName = Methods.EncodeGameText(landb.landbs[i].actorName, useUtf8ForActorName);
@@ -367,7 +367,7 @@ namespace TTG_Tools.Texts
                     landb.newLandbFileSize += 4 + landb.landbs[i].actorNameSize;
 
                     byte[] tmpActorSpeech = Methods.EncodeGameText(landb.landbs[i].actorSpeech, landb.isUnicode);
-                    if (landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
+                    if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
                     {
                         string speechText = landb.landbs[i].actorSpeech;
                         bool endsUtf8Marker = (speechText.IndexOf("(utf8)") > 0) && (speechText.IndexOf("(utf8)") == speechText.Length - 6);

--- a/master/Texts/LandbWorker.cs
+++ b/master/Texts/LandbWorker.cs
@@ -246,7 +246,7 @@ namespace TTG_Tools.Texts
             return landb;
         }
 
-        private static int RebuildLandb(BinaryReader br, string outputFile, LandbClass landb)
+        private static int RebuildLandb(BinaryReader br, string outputFile, LandbClass landb, string inputFileName, bool openingCreditsReplacementMode)
         {
             if (File.Exists(outputFile)) File.Delete(outputFile);
 
@@ -358,7 +358,8 @@ namespace TTG_Tools.Texts
                     byte[] tmpActorName = Methods.EncodeGameText(landb.landbs[i].actorName, landb.isUnicode);
                     if (MainMenu.settings.supportTwdNintendoSwitch && landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
                     {
-                        bool useUtf8ForActorName = !Methods.IsTextRepresentableInActiveEncoding(landb.landbs[i].actorName);
+                        bool useUtf8ForActorName = !Methods.IsTextRepresentableInActiveEncoding(landb.landbs[i].actorName)
+                            || Methods.ShouldForceUtf8ForLandbString(inputFileName, landb.landbs[i].actorName, openingCreditsReplacementMode);
                         tmpActorName = Methods.EncodeGameText(landb.landbs[i].actorName, useUtf8ForActorName);
                     }
                     landb.landbs[i].actorNameSize = tmpActorName.Length;
@@ -386,7 +387,8 @@ namespace TTG_Tools.Texts
                         }
                         else
                         {
-                            bool useUtf8ForSpeech = !Methods.IsTextRepresentableInActiveEncoding(speechText);
+                            bool useUtf8ForSpeech = !Methods.IsTextRepresentableInActiveEncoding(speechText)
+                                || Methods.ShouldForceUtf8ForLandbString(inputFileName, speechText, openingCreditsReplacementMode);
                             tmpActorSpeech = Methods.EncodeGameText(speechText, useUtf8ForSpeech);
                         }
                     }
@@ -641,7 +643,7 @@ namespace TTG_Tools.Texts
 
                     string outputFile = MainMenu.settings.pathForOutputFolder + "\\" + fi.Name;
 
-                    int rebuildResult = RebuildLandb(br, outputFile, landbs);
+                    int rebuildResult = RebuildLandb(br, outputFile, landbs, fi.Name, mapOpeningCreditsReplacement);
                     
                     br.Close();
                     ms.Close();

--- a/master/Texts/LandbWorker.cs
+++ b/master/Texts/LandbWorker.cs
@@ -101,7 +101,7 @@ namespace TTG_Tools.Texts
                         landb.newLandbFileSize += landb.landbs[i].anmNameSize;
                         landb.newBlockLength += landb.landbs[i].anmNameSize;
 
-                        landb.landbs[i].anmName = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(tmp);
+                        landb.landbs[i].anmName = Methods.DecodeGameText(tmp, false);
                     }
 
                     landb.landbs[i].blockWavNameSize = br.ReadInt32();
@@ -127,7 +127,7 @@ namespace TTG_Tools.Texts
                         landb.newLandbFileSize += landb.landbs[i].wavNameSize;
                         landb.newBlockLength += landb.landbs[i].wavNameSize;
 
-                        landb.landbs[i].wavName = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(tmp);
+                        landb.landbs[i].wavName = Methods.DecodeGameText(tmp, false);
                     }
 
                     landb.landbs[i].blockUnknownNameSize = br.ReadInt32();
@@ -142,7 +142,7 @@ namespace TTG_Tools.Texts
                     landb.newLandbFileSize += landb.landbs[i].unknownNameSize;
                     landb.newBlockLength += landb.landbs[i].unknownNameSize;
 
-                    landb.landbs[i].unknownName = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(tmp);
+                    landb.landbs[i].unknownName = Methods.DecodeGameText(tmp, false);
 
                     landb.landbs[i].zero2 = br.ReadInt32();
                     landb.newLandbFileSize += 4;
@@ -159,11 +159,11 @@ namespace TTG_Tools.Texts
                     //Don't calculate new size with actor name!
                     landb.landbs[i].actorNameSize = br.ReadInt32();
                     tmp = br.ReadBytes(landb.landbs[i].actorNameSize);
-                    landb.landbs[i].actorName = landb.isUnicode ? Encoding.UTF8.GetString(tmp) : Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(tmp);
+                    landb.landbs[i].actorName = Methods.DecodeGameText(tmp, landb.isUnicode);
                     if (landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
                     {
                         //landb.landbs[i].actorName = Methods.isUTF8String(tmp) ? Encoding.UTF8.GetString(tmp) : Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(tmp);
-                        landb.landbs[i].actorName = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(tmp);
+                        landb.landbs[i].actorName = Methods.DecodeGameText(tmp, false);
                     }
 
                     landb.landbs[i].blockActorSpeechSize = br.ReadInt32();
@@ -172,11 +172,11 @@ namespace TTG_Tools.Texts
 
                     landb.landbs[i].actorSpeechSize = br.ReadInt32();
                     tmp = br.ReadBytes(landb.landbs[i].actorSpeechSize);
-                    landb.landbs[i].actorSpeech = landb.isUnicode ? Encoding.UTF8.GetString(tmp) : Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(tmp);
+                    landb.landbs[i].actorSpeech = Methods.DecodeGameText(tmp, landb.isUnicode);
                     if (landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
                     {
                         //landb.landbs[i].actorSpeech = Methods.isUTF8String(tmp) ? Encoding.UTF8.GetString(tmp) : Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(tmp);
-                        landb.landbs[i].actorSpeech = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetString(tmp);
+                        landb.landbs[i].actorSpeech = Methods.DecodeGameText(tmp, false);
 
                         if(Methods.isUTF8String(tmp))
                         {
@@ -327,7 +327,7 @@ namespace TTG_Tools.Texts
                     else
                     {
                         bw.Write(landb.landbs[i].anmNameSize);
-                        tmp = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(landb.landbs[i].anmName);
+                        tmp = Methods.EncodeGameText(landb.landbs[i].anmName, false);
                     }
 
                     bw.Write(tmp);
@@ -347,7 +347,7 @@ namespace TTG_Tools.Texts
                     else
                     {
                         bw.Write(landb.landbs[i].wavNameSize);
-                        tmp = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(landb.landbs[i].wavName);
+                        tmp = Methods.EncodeGameText(landb.landbs[i].wavName, false);
                     }
 
                     bw.Write(tmp);
@@ -355,19 +355,19 @@ namespace TTG_Tools.Texts
                     bw.Write(landb.landbs[i].blockUnknownNameSize);
                     bw.Write(landb.landbs[i].unknownNameSize);
 
-                    tmp = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(landb.landbs[i].unknownName);
+                    tmp = Methods.EncodeGameText(landb.landbs[i].unknownName, false);
                     bw.Write(tmp);
 
                     bw.Write(landb.landbs[i].zero2);
 
-                    byte[] tmpActorName = landb.isUnicode ? Encoding.UTF8.GetBytes(landb.landbs[i].actorName) : Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(landb.landbs[i].actorName);
-                    if (landb.isUnicode && (MainMenu.settings.unicodeSettings == 2)) tmpActorName = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(landb.landbs[i].actorName);
+                    byte[] tmpActorName = Methods.EncodeGameText(landb.landbs[i].actorName, landb.isUnicode);
+                    if (landb.isUnicode && (MainMenu.settings.unicodeSettings == 2)) tmpActorName = Methods.EncodeGameText(landb.landbs[i].actorName, false);
                     landb.landbs[i].actorNameSize = tmpActorName.Length;
                     landb.landbs[i].blockActorNameSize = landb.landbs[i].actorNameSize + 8;
                     landb.newBlockLength += 4 + landb.landbs[i].actorNameSize;
                     landb.newLandbFileSize += 4 + landb.landbs[i].actorNameSize;
 
-                    byte[] tmpActorSpeech = landb.isUnicode ? Encoding.UTF8.GetBytes(landb.landbs[i].actorSpeech) : Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(landb.landbs[i].actorSpeech);
+                    byte[] tmpActorSpeech = Methods.EncodeGameText(landb.landbs[i].actorSpeech, landb.isUnicode);
                     if (landb.isUnicode && (MainMenu.settings.unicodeSettings == 2))
                     {
                         //tmpActorSpeech = landb.landbs[i].actorName.Contains("\"") ? Encoding.UTF8.GetBytes(landb.landbs[i].actorSpeech) : Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(landb.landbs[i].actorSpeech);
@@ -382,7 +382,7 @@ namespace TTG_Tools.Texts
                             tmpStr = Methods.ConvertString(tmpStr, false);
                             tmpActorSpeech = Encoding.UTF8.GetBytes(tmpStr);
                         }
-                        else tmpActorSpeech = Encoding.GetEncoding(MainMenu.settings.ASCII_N).GetBytes(landb.landbs[i].actorSpeech);
+                        else tmpActorSpeech = Methods.EncodeGameText(landb.landbs[i].actorSpeech, false);
                     }
                     landb.landbs[i].actorSpeechSize = tmpActorSpeech.Length;
                     landb.landbs[i].blockActorSpeechSize = landb.landbs[i].actorSpeechSize + 8;


### PR DESCRIPTION
### Motivation
- Fix encoding errors (replacement characters `�`) when extracting and reimporting text from The Walking Dead (The Telltale Definitive Series / Season One) Nintendo Switch files by providing a per-game, Switch-specific encoding mode.

### Description
- Added a persisted boolean setting `supportTwdNintendoSwitch` to `Settings` and updated the default `MainMenu.settings` initialization to include the new field (`master/Settings.cs`, `master/MainMenu.cs`).
- Added a new radio button UI option `"Support for The Walking Dead Nintendo Switch"` to the Settings form and wired it to the persisted setting (`master/FormSettings.Designer.cs`, `master/FormSettings.cs`).
- Centralized game text encoding logic in two helpers `Methods.DecodeGameText(byte[], bool)` and `Methods.EncodeGameText(string, bool)` which use UTF-8 normally but switch to ANSI codepage 1252 when `supportTwdNintendoSwitch` is enabled (`master/Methods.cs`).
- Updated `.prop` extraction/import code to use the new helpers so exported `.txt` remains UTF-8 while reading/writing binary uses the proper ANSI when the Switch mode is active (`master/ForThreads.cs`).
- Updated `.landb` parsing and rebuild logic to use the new helpers for all non-unicode fields and to encode/decode actor names and speeches consistently during extract/import so round-trip preserves accents/special characters (`master/Texts/LandbWorker.cs`).