### PR TITLE
Fix Nintendo Switch BC5U extraction by enabling BC4-BC7 swizzle paths

### DIFF
--- a/master/Graphics/Swizzles/NintendoSwitch.cs
+++ b/master/Graphics/Swizzles/NintendoSwitch.cs
@@ -32,13 +32,17 @@ namespace TTG_Tools.Graphics.Swizzles
         {
             switch (code)
             {
-                case 0x40:
+                case 0x40: // BC1
+                case 0x43: // BC4
                     return bpps[8];
 
-                case 0x41:
+                case 0x41: // BC2
                     return bpps[9];
 
-                case 0x42:
+                case 0x42: // BC3
+                case 0x44: // BC5
+                case 0x45: // BC6
+                case 0x46: // BC7
                     return bpps[10];
             }
             return 0;
@@ -156,7 +160,7 @@ namespace TTG_Tools.Graphics.Swizzles
             int originWidth = width;
             int originHeight = height;
 
-            if (code >= 0x40 && code <= 0x42)
+            if (code >= 0x40 && code <= 0x46)
             {
                 originHeight = (originHeight + 3) / 4;
                 originWidth = (originWidth + 3) / 4;
@@ -191,7 +195,7 @@ namespace TTG_Tools.Graphics.Swizzles
             int origin_width = width;
             int origin_height = height;
 
-            if(code >= 0x40 && code <= 0x42)
+            if(code >= 0x40 && code <= 0x46)
             {
                 origin_height = (origin_height + 3) / 4;
                 origin_width = (origin_width + 3) / 4;

--- a/master/Graphics/TextureWorker.cs
+++ b/master/Graphics/TextureWorker.cs
@@ -12,7 +12,7 @@ namespace TTG_Tools.Graphics
     {
         static uint[] TexCodes = { 0x00, 0x4, 0x10, 0x11, 0x25, 0x40, 0x41, 0x42, 0x43, 0x43, 0x44, 0x45, 0x46 };
         static string[] FourCC = { "\0\0\0\0", "\0\0\0\0", "\0\0\0\0", "\0\0\0\0", "\x74\0\0\0", "DXT1", "DXT3", "DXT5", "BC4U", "ATI1", "ATI2", "BC6H", "ATI2" };
-        static string[] Formats = { "uncompressed 8.8.8.8 ARGB", "uncompressed 4.4.4.4 ARGB", "Alpha 8 bit (A8)", "IL8", "uncompressed 32f.32f.32f.32f ARGB", "DXT1", "DXT3", "DXT5", "BC4", "BC5", "BC6", "BC7" };
+        static string[] Formats = { "uncompressed 8.8.8.8 ARGB", "uncompressed 4.4.4.4 ARGB", "Alpha 8 bit (A8)", "IL8", "uncompressed 32f.32f.32f.32f ARGB", "DXT1", "DXT3", "DXT5", "BC4", "BC4", "BC5", "BC6", "BC7" };
 
         private static bool IsVitaPvrFormat(uint textureFormat)
         {


### PR DESCRIPTION
### Motivation
- BC5U textures from the Nintendo Switch were being exported as corrupted images because the Switch swizzle/deswizzle routine did not recognize the BC5 format code and returned `bpp == 0`, skipping deswizzling. 
- The Switch code treated block-compressed formats only for `0x40..0x42`, excluding BC4/BC5/BC6/BC7 codes and producing wrong mip/size calculations. 
- The human-readable format label mapping was offset so internal format `0x44` (BC5) could appear as BC6 in logs and exports.

### Description
- Updated `master/Graphics/Swizzles/NintendoSwitch.cs` to extend `GetBpp` so BC4/BC5/BC6/BC7 codes map to the correct bytes-per-pixel, and adjusted the block-compressed checks from `0x40..0x42` to `0x40..0x46` used by swizzle and mip-size logic, enabling proper deswizzle for BC5 (`0x44`).
- Adjusted the `NintendoSwizzle`/mip-size paths to treat BC4..BC7 as block-compressed so padded dimensions and required swizzled sizes are computed correctly for Switch textures.
- Fixed the human-readable formats table in `master/Graphics/TextureWorker.cs` so the textual mapping aligns with internal format codes and `0x44` is reported as `BC5` instead of shifting labels.

### Testing
- Attempted an automated build with `msbuild "master/TTG Tools.sln" /t:Build /p:Configuration=Release`, but the tool was not available in the environment and the build could not be run. (failed)
- Attempted an automated build with `dotnet build "master/TTG Tools.sln" -c Release`, but `dotnet` was not available in the environment and the build could not be run. (failed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993776475808326866235ee415a2746)