### PR TITLE
Always use UTF-8 for PROP reinsertion in TWD Nintendo Switch mode

### DIFF
--- a/master/Methods.cs
+++ b/master/Methods.cs
@@ -26,19 +26,15 @@ namespace TTG_Tools
 
         public static bool IsCheckpointPropAnsiException(string fileName)
         {
-            if (!MainMenu.settings.supportTwdNintendoSwitch) return false;
-
-            string safeName = Path.GetFileName(fileName ?? "");
-            return safeName.Equals("checkpoint_text.prop", StringComparison.OrdinalIgnoreCase);
+            return false;
         }
 
         public static bool ShouldUseUtf8ForPropReinsert(string fileName, bool headerIs6VSM)
         {
             if (MainMenu.settings.supportTwdNintendoSwitch)
             {
-                // New requested strategy for Switch mode:
-                // all PROP reinsertion in UTF-8, except checkpoint_text.prop in ANSI.
-                return !IsCheckpointPropAnsiException(fileName);
+                // Switch mode: all PROP reinsertion in UTF-8.
+                return true;
             }
 
             return headerIs6VSM;


### PR DESCRIPTION
### Motivation
- Ensure PROP files for "Support for The Walking Dead Nintendo Switch" are reinserted in UTF-8 instead of treating `checkpoint_text.prop` as an ANSI exception.

### Description
- Removed the ANSI exception by making `IsCheckpointPropAnsiException(...)` always return `false` and changed `ShouldUseUtf8ForPropReinsert(...)` to return `true` when `supportTwdNintendoSwitch` is enabled so all `.prop` reinserts use UTF-8.