### PR TITLE
Revert FontEditor PS4 swizzle block-dimension change

### DIFF
--- a/master/Graphics/Swizzles/PS4.cs
+++ b/master/Graphics/Swizzles/PS4.cs
@@ -11,19 +11,32 @@ namespace TTG_Tools.Graphics.Swizzles
     {
         public static byte[] Swizzle(byte[] data, int width, int height, int blockSize)
         {
-            return DoSwizzle(data, width, height, blockSize, false);
+            return DoSwizzle(data, width, height, blockSize, 4, 4, false);
+        }
+
+        public static byte[] Swizzle(byte[] data, int width, int height, int blockSize, int blockWidth, int blockHeight)
+        {
+            return DoSwizzle(data, width, height, blockSize, blockWidth, blockHeight, false);
         }
 
         public static byte[] Unswizzle(byte[] data, int width, int height, int blockSize)
         {
-            return DoSwizzle(data, width, height, blockSize, true);
+            return DoSwizzle(data, width, height, blockSize, 4, 4, true);
         }
 
-        private static byte[] DoSwizzle(byte[] data, int width, int height, int blockSize, bool unswizzle)
+        public static byte[] Unswizzle(byte[] data, int width, int height, int blockSize, int blockWidth, int blockHeight)
         {
-            // 1. Calcula as dimensões em "Texels" (Blocos de compressão 4x4 pixels)
-            var heightTexels = height / 4;
-            var widthTexels = width / 4;
+            return DoSwizzle(data, width, height, blockSize, blockWidth, blockHeight, true);
+        }
+
+        private static byte[] DoSwizzle(byte[] data, int width, int height, int blockSize, int blockWidth, int blockHeight, bool unswizzle)
+        {
+            blockWidth = blockWidth < 1 ? 1 : blockWidth;
+            blockHeight = blockHeight < 1 ? 1 : blockHeight;
+
+            // 1. Calcula as dimensões em "Texels" (blocos do formato)
+            var heightTexels = Math.Max(1, (height + blockHeight - 1) / blockHeight);
+            var widthTexels = Math.Max(1, (width + blockWidth - 1) / blockWidth);
 
             // 2. Calcula o alinhamento necessário para o PS4 (Blocos de 8x8 Texels = 32x32 Pixels)
             var heightTexelsAligned = (heightTexels + 7) / 8;

--- a/master/Graphics/TextureWorker.cs
+++ b/master/Graphics/TextureWorker.cs
@@ -1802,11 +1802,13 @@ namespace TTG_Tools.Graphics
                             int h = tex.Height;
 
                             int blockSize = tex.TextureFormat == 0x40 || tex.TextureFormat == 0x43 ? 8 : 16;
+                            int blockWidth = tex.TextureFormat >= 0x40 && tex.TextureFormat <= 0x46 ? 4 : 1;
+                            int blockHeight = tex.TextureFormat >= 0x40 && tex.TextureFormat <= 0x46 ? 4 : 1;
 
                             for (int i = 0; i < tex.Tex.MipCount; i++)
                             {
                                 if (tex.Tex.Textures[i].Block.Length < blockSize) blockSize = tex.Tex.Textures[i].Block.Length;
-                                tex.Tex.Textures[i].Block = PS4.Swizzle(tex.Tex.Textures[i].Block, w, h, blockSize);
+                                tex.Tex.Textures[i].Block = PS4.Swizzle(tex.Tex.Textures[i].Block, w, h, blockSize, blockWidth, blockHeight);
 
                                 if (w > 1) w /= 2;
                                 if (h > 1) h /= 2;
@@ -2504,11 +2506,13 @@ namespace TTG_Tools.Graphics
                     int w = tex.Width;
                     int h = tex.Height;
                     int blockSize = tex.TextureFormat == 0x40 || tex.TextureFormat == 0x43 ? 8 : 16;
+                    int blockWidth = tex.TextureFormat >= 0x40 && tex.TextureFormat <= 0x46 ? 4 : 1;
+                    int blockHeight = tex.TextureFormat >= 0x40 && tex.TextureFormat <= 0x46 ? 4 : 1;
 
                     for (int i = 0; i < tex.Tex.MipCount; i++)
                     {
                         if (tex.Tex.Textures[i].Block.Length < blockSize) blockSize = tex.Tex.Textures[i].Block.Length;
-                        tex.Tex.Textures[i].Block = PS4.Unswizzle(tex.Tex.Textures[i].Block, w, h, blockSize);
+                        tex.Tex.Textures[i].Block = PS4.Unswizzle(tex.Tex.Textures[i].Block, w, h, blockSize, blockWidth, blockHeight);
 
                         if (w > 1) w /= 2;
                         if (h > 1) h /= 2;


### PR DESCRIPTION
### Motivation
- Restore the FontEditor code path to use the original PS4 swizzle API signature (no `blockWidth`/`blockHeight`) so font import/export behavior is unchanged.

### Description
- Reverted `master/FontEditor.cs` to remove the `blockWidth`/`blockHeight` variables and restored the call to `PS4.Swizzle(NewTex.Tex.Textures[i].Block, w, h, blockSize)` for the PS4/font code path, with no other logical changes.

### Testing
- Ran `git diff -- master/FontEditor.cs` to confirm the file was reverted and ran `git diff --check` to ensure there are no whitespace/patch issues; both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994dec3e344832aab19096f5579a02e)