### PR TITLE
Add Mod Creator UI and packaging logic for Poker Night Remastered

### DIFF
--- a/master/MainMenu.Designer.cs
+++ b/master/MainMenu.Designer.cs
@@ -39,6 +39,7 @@
             this.settingsBtn = new System.Windows.Forms.Button();
             this.archivePackerBtn = new System.Windows.Forms.Button();
             this.arcUnpackerBtn = new System.Windows.Forms.Button();
+            this.modCreatorBtn = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // autopackerBtn
@@ -119,12 +120,23 @@
             this.arcUnpackerBtn.UseVisualStyleBackColor = true;
             this.arcUnpackerBtn.Click += new System.EventHandler(this.arcUnpackerBtn_Click);
             // 
+            // modCreatorBtn
+            // 
+            this.modCreatorBtn.Location = new System.Drawing.Point(127, 108);
+            this.modCreatorBtn.Name = "modCreatorBtn";
+            this.modCreatorBtn.Size = new System.Drawing.Size(112, 23);
+            this.modCreatorBtn.TabIndex = 14;
+            this.modCreatorBtn.Text = "Mod Creator";
+            this.modCreatorBtn.UseVisualStyleBackColor = true;
+            this.modCreatorBtn.Click += new System.EventHandler(this.modCreatorBtn_Click);
+            // 
             // MainMenu
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(370, 191);
             this.Controls.Add(this.arcUnpackerBtn);
+            this.Controls.Add(this.modCreatorBtn);
             this.Controls.Add(this.archivePackerBtn);
             this.Controls.Add(this.settingsBtn);
             this.Controls.Add(this.textEditorBtn);
@@ -153,5 +165,6 @@
         private System.Windows.Forms.Button settingsBtn;
         private System.Windows.Forms.Button archivePackerBtn;
         private System.Windows.Forms.Button arcUnpackerBtn;
+        private System.Windows.Forms.Button modCreatorBtn;
     }
 }

--- a/master/MainMenu.cs
+++ b/master/MainMenu.cs
@@ -356,5 +356,14 @@ namespace TTG_Tools
                 arcUnpackerForm.Show();
             }
         }
+
+        private void modCreatorBtn_Click(object sender, EventArgs e)
+        {
+            if (Application.OpenForms.OfType<ModCreator>().Count() == 0)
+            {
+                Form modCreatorForm = new ModCreator();
+                modCreatorForm.Show();
+            }
+        }
     }
 }

--- a/master/ModCreator.Designer.cs
+++ b/master/ModCreator.Designer.cs
@@ -26,6 +26,9 @@
             this.gameComboBox = new System.Windows.Forms.ComboBox();
             this.createModButton = new System.Windows.Forms.Button();
             this.logListBox = new System.Windows.Forms.ListBox();
+            this.outputFolderLabel = new System.Windows.Forms.Label();
+            this.outputFolderTextBox = new System.Windows.Forms.TextBox();
+            this.browseOutputButton = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // inputFolderLabel
@@ -57,7 +60,7 @@
             // modNameLabel
             // 
             this.modNameLabel.AutoSize = true;
-            this.modNameLabel.Location = new System.Drawing.Point(22, 44);
+            this.modNameLabel.Location = new System.Drawing.Point(22, 73);
             this.modNameLabel.Name = "modNameLabel";
             this.modNameLabel.Size = new System.Drawing.Size(58, 13);
             this.modNameLabel.TabIndex = 3;
@@ -65,7 +68,7 @@
             // 
             // modNameTextBox
             // 
-            this.modNameTextBox.Location = new System.Drawing.Point(103, 41);
+            this.modNameTextBox.Location = new System.Drawing.Point(103, 70);
             this.modNameTextBox.Name = "modNameTextBox";
             this.modNameTextBox.Size = new System.Drawing.Size(196, 20);
             this.modNameTextBox.TabIndex = 4;
@@ -73,7 +76,7 @@
             // gameLabel
             // 
             this.gameLabel.AutoSize = true;
-            this.gameLabel.Location = new System.Drawing.Point(43, 73);
+            this.gameLabel.Location = new System.Drawing.Point(43, 102);
             this.gameLabel.Name = "gameLabel";
             this.gameLabel.Size = new System.Drawing.Size(38, 13);
             this.gameLabel.TabIndex = 5;
@@ -83,14 +86,14 @@
             // 
             this.gameComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
             this.gameComboBox.FormattingEnabled = true;
-            this.gameComboBox.Location = new System.Drawing.Point(103, 70);
+            this.gameComboBox.Location = new System.Drawing.Point(103, 99);
             this.gameComboBox.Name = "gameComboBox";
             this.gameComboBox.Size = new System.Drawing.Size(407, 21);
             this.gameComboBox.TabIndex = 6;
             // 
             // createModButton
             // 
-            this.createModButton.Location = new System.Drawing.Point(516, 68);
+            this.createModButton.Location = new System.Drawing.Point(516, 97);
             this.createModButton.Name = "createModButton";
             this.createModButton.Size = new System.Drawing.Size(75, 23);
             this.createModButton.TabIndex = 7;
@@ -101,16 +104,45 @@
             // logListBox
             // 
             this.logListBox.FormattingEnabled = true;
-            this.logListBox.Location = new System.Drawing.Point(15, 105);
+            this.logListBox.Location = new System.Drawing.Point(15, 136);
             this.logListBox.Name = "logListBox";
             this.logListBox.Size = new System.Drawing.Size(576, 147);
             this.logListBox.TabIndex = 8;
+            // 
+            // outputFolderLabel
+            // 
+            this.outputFolderLabel.AutoSize = true;
+            this.outputFolderLabel.Location = new System.Drawing.Point(3, 44);
+            this.outputFolderLabel.Name = "outputFolderLabel";
+            this.outputFolderLabel.Size = new System.Drawing.Size(74, 13);
+            this.outputFolderLabel.TabIndex = 9;
+            this.outputFolderLabel.Text = "Output folder:";
+            // 
+            // outputFolderTextBox
+            // 
+            this.outputFolderTextBox.Location = new System.Drawing.Point(103, 41);
+            this.outputFolderTextBox.Name = "outputFolderTextBox";
+            this.outputFolderTextBox.Size = new System.Drawing.Size(407, 20);
+            this.outputFolderTextBox.TabIndex = 10;
+            // 
+            // browseOutputButton
+            // 
+            this.browseOutputButton.Location = new System.Drawing.Point(516, 39);
+            this.browseOutputButton.Name = "browseOutputButton";
+            this.browseOutputButton.Size = new System.Drawing.Size(75, 23);
+            this.browseOutputButton.TabIndex = 11;
+            this.browseOutputButton.Text = "Browse...";
+            this.browseOutputButton.UseVisualStyleBackColor = true;
+            this.browseOutputButton.Click += new System.EventHandler(this.browseOutputButton_Click);
             // 
             // ModCreator
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(606, 269);
+            this.ClientSize = new System.Drawing.Size(606, 299);
+            this.Controls.Add(this.browseOutputButton);
+            this.Controls.Add(this.outputFolderTextBox);
+            this.Controls.Add(this.outputFolderLabel);
             this.Controls.Add(this.logListBox);
             this.Controls.Add(this.createModButton);
             this.Controls.Add(this.gameComboBox);
@@ -141,5 +173,8 @@
         private System.Windows.Forms.ComboBox gameComboBox;
         private System.Windows.Forms.Button createModButton;
         private System.Windows.Forms.ListBox logListBox;
+        private System.Windows.Forms.Label outputFolderLabel;
+        private System.Windows.Forms.TextBox outputFolderTextBox;
+        private System.Windows.Forms.Button browseOutputButton;
     }
 }

--- a/master/ModCreator.Designer.cs
+++ b/master/ModCreator.Designer.cs
@@ -1,0 +1,145 @@
+﻿namespace TTG_Tools
+{
+    partial class ModCreator
+    {
+        private System.ComponentModel.IContainer components = null;
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && (components != null))
+            {
+                components.Dispose();
+            }
+            base.Dispose(disposing);
+        }
+
+        #region Windows Form Designer generated code
+
+        private void InitializeComponent()
+        {
+            this.inputFolderLabel = new System.Windows.Forms.Label();
+            this.inputFolderTextBox = new System.Windows.Forms.TextBox();
+            this.browseInputButton = new System.Windows.Forms.Button();
+            this.modNameLabel = new System.Windows.Forms.Label();
+            this.modNameTextBox = new System.Windows.Forms.TextBox();
+            this.gameLabel = new System.Windows.Forms.Label();
+            this.gameComboBox = new System.Windows.Forms.ComboBox();
+            this.createModButton = new System.Windows.Forms.Button();
+            this.logListBox = new System.Windows.Forms.ListBox();
+            this.SuspendLayout();
+            // 
+            // inputFolderLabel
+            // 
+            this.inputFolderLabel.AutoSize = true;
+            this.inputFolderLabel.Location = new System.Drawing.Point(12, 15);
+            this.inputFolderLabel.Name = "inputFolderLabel";
+            this.inputFolderLabel.Size = new System.Drawing.Size(65, 13);
+            this.inputFolderLabel.TabIndex = 0;
+            this.inputFolderLabel.Text = "Input folder:";
+            // 
+            // inputFolderTextBox
+            // 
+            this.inputFolderTextBox.Location = new System.Drawing.Point(103, 12);
+            this.inputFolderTextBox.Name = "inputFolderTextBox";
+            this.inputFolderTextBox.Size = new System.Drawing.Size(407, 20);
+            this.inputFolderTextBox.TabIndex = 1;
+            // 
+            // browseInputButton
+            // 
+            this.browseInputButton.Location = new System.Drawing.Point(516, 10);
+            this.browseInputButton.Name = "browseInputButton";
+            this.browseInputButton.Size = new System.Drawing.Size(75, 23);
+            this.browseInputButton.TabIndex = 2;
+            this.browseInputButton.Text = "Browse...";
+            this.browseInputButton.UseVisualStyleBackColor = true;
+            this.browseInputButton.Click += new System.EventHandler(this.browseInputButton_Click);
+            // 
+            // modNameLabel
+            // 
+            this.modNameLabel.AutoSize = true;
+            this.modNameLabel.Location = new System.Drawing.Point(22, 44);
+            this.modNameLabel.Name = "modNameLabel";
+            this.modNameLabel.Size = new System.Drawing.Size(58, 13);
+            this.modNameLabel.TabIndex = 3;
+            this.modNameLabel.Text = "Mod name:";
+            // 
+            // modNameTextBox
+            // 
+            this.modNameTextBox.Location = new System.Drawing.Point(103, 41);
+            this.modNameTextBox.Name = "modNameTextBox";
+            this.modNameTextBox.Size = new System.Drawing.Size(196, 20);
+            this.modNameTextBox.TabIndex = 4;
+            // 
+            // gameLabel
+            // 
+            this.gameLabel.AutoSize = true;
+            this.gameLabel.Location = new System.Drawing.Point(43, 73);
+            this.gameLabel.Name = "gameLabel";
+            this.gameLabel.Size = new System.Drawing.Size(38, 13);
+            this.gameLabel.TabIndex = 5;
+            this.gameLabel.Text = "Game:";
+            // 
+            // gameComboBox
+            // 
+            this.gameComboBox.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
+            this.gameComboBox.FormattingEnabled = true;
+            this.gameComboBox.Location = new System.Drawing.Point(103, 70);
+            this.gameComboBox.Name = "gameComboBox";
+            this.gameComboBox.Size = new System.Drawing.Size(407, 21);
+            this.gameComboBox.TabIndex = 6;
+            // 
+            // createModButton
+            // 
+            this.createModButton.Location = new System.Drawing.Point(516, 68);
+            this.createModButton.Name = "createModButton";
+            this.createModButton.Size = new System.Drawing.Size(75, 23);
+            this.createModButton.TabIndex = 7;
+            this.createModButton.Text = "Create";
+            this.createModButton.UseVisualStyleBackColor = true;
+            this.createModButton.Click += new System.EventHandler(this.createModButton_Click);
+            // 
+            // logListBox
+            // 
+            this.logListBox.FormattingEnabled = true;
+            this.logListBox.Location = new System.Drawing.Point(15, 105);
+            this.logListBox.Name = "logListBox";
+            this.logListBox.Size = new System.Drawing.Size(576, 147);
+            this.logListBox.TabIndex = 8;
+            // 
+            // ModCreator
+            // 
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(606, 269);
+            this.Controls.Add(this.logListBox);
+            this.Controls.Add(this.createModButton);
+            this.Controls.Add(this.gameComboBox);
+            this.Controls.Add(this.gameLabel);
+            this.Controls.Add(this.modNameTextBox);
+            this.Controls.Add(this.modNameLabel);
+            this.Controls.Add(this.browseInputButton);
+            this.Controls.Add(this.inputFolderTextBox);
+            this.Controls.Add(this.inputFolderLabel);
+            this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
+            this.MaximizeBox = false;
+            this.Name = "ModCreator";
+            this.Text = "Mod Creator";
+            this.Load += new System.EventHandler(this.ModCreator_Load);
+            this.ResumeLayout(false);
+            this.PerformLayout();
+
+        }
+
+        #endregion
+
+        private System.Windows.Forms.Label inputFolderLabel;
+        private System.Windows.Forms.TextBox inputFolderTextBox;
+        private System.Windows.Forms.Button browseInputButton;
+        private System.Windows.Forms.Label modNameLabel;
+        private System.Windows.Forms.TextBox modNameTextBox;
+        private System.Windows.Forms.Label gameLabel;
+        private System.Windows.Forms.ComboBox gameComboBox;
+        private System.Windows.Forms.Button createModButton;
+        private System.Windows.Forms.ListBox logListBox;
+    }
+}

--- a/master/ModCreator.cs
+++ b/master/ModCreator.cs
@@ -19,6 +19,13 @@ namespace TTG_Tools
             InitializeComponent();
             folderDialog.IsFolderPicker = true;
             folderDialog.EnsurePathExists = true;
+
+            AllowDrop = true;
+            DragEnter += InputFolder_DragEnter;
+            DragDrop += InputFolder_DragDrop;
+            inputFolderTextBox.AllowDrop = true;
+            inputFolderTextBox.DragEnter += InputFolder_DragEnter;
+            inputFolderTextBox.DragDrop += InputFolder_DragDrop;
         }
 
         private void ModCreator_Load(object sender, EventArgs e)
@@ -27,6 +34,11 @@ namespace TTG_Tools
             gameComboBox.Items.Add(pokerNightProfile.GameDisplayName);
             gameComboBox.SelectedIndex = 0;
             gameComboBox.Enabled = false; // estrutura preparada, mas bloqueada para este jogo nesta fase.
+
+            if (string.IsNullOrWhiteSpace(outputFolderTextBox.Text) && Directory.Exists(inputFolderTextBox.Text))
+            {
+                outputFolderTextBox.Text = Path.Combine(inputFolderTextBox.Text, "ModCreator_Output");
+            }
         }
 
         private void browseInputButton_Click(object sender, EventArgs e)
@@ -34,18 +46,38 @@ namespace TTG_Tools
             if (folderDialog.ShowDialog() == CommonFileDialogResult.Ok)
             {
                 inputFolderTextBox.Text = folderDialog.FileName;
+
+                if (string.IsNullOrWhiteSpace(outputFolderTextBox.Text))
+                {
+                    outputFolderTextBox.Text = Path.Combine(folderDialog.FileName, "ModCreator_Output");
+                }
+            }
+        }
+
+
+        private void browseOutputButton_Click(object sender, EventArgs e)
+        {
+            if (folderDialog.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                outputFolderTextBox.Text = folderDialog.FileName;
             }
         }
 
         private async void createModButton_Click(object sender, EventArgs e)
         {
             string inputFolder = inputFolderTextBox.Text.Trim();
+            string outputFolder = outputFolderTextBox.Text.Trim();
             string modName = NormalizeModName(modNameTextBox.Text.Trim());
 
             if (!Directory.Exists(inputFolder))
             {
                 MessageBox.Show("Input folder doesn't exist.", "Error");
                 return;
+            }
+
+            if (!Directory.Exists(outputFolder))
+            {
+                Directory.CreateDirectory(outputFolder);
             }
 
             if (string.IsNullOrWhiteSpace(modName))
@@ -55,8 +87,8 @@ namespace TTG_Tools
             }
 
             string archiveFileName = pokerNightProfile.BuildArchiveFileName(modName);
-            string archivePath = Path.Combine(inputFolder, archiveFileName);
-            string luaPath = Path.Combine(inputFolder, modName + ".lua");
+            string archivePath = Path.Combine(outputFolder, archiveFileName);
+            string luaPath = Path.Combine(outputFolder, pokerNightProfile.BuildLuaFileName(modName));
 
             SetUiEnabled(false);
             logListBox.Items.Clear();
@@ -64,7 +96,7 @@ namespace TTG_Tools
 
             try
             {
-                await Task.Run(() => CreateModPackage(inputFolder, archivePath, luaPath, modName, archiveFileName));
+                await Task.Run(() => CreateModPackage(inputFolder, outputFolder, archivePath, luaPath, modName, archiveFileName));
                 AddLog("Mod created successfully.");
                 MessageBox.Show("Mod created successfully.", "Success");
             }
@@ -79,10 +111,11 @@ namespace TTG_Tools
             }
         }
 
-        private void CreateModPackage(string inputFolder, string archivePath, string luaPath, string modName, string archiveFileName)
+        private void CreateModPackage(string inputFolder, string outputFolder, string archivePath, string luaPath, string modName, string archiveFileName)
         {
             byte[] gameKey = GetEncryptionKeyForGame(pokerNightProfile.GameDisplayName);
 
+            AddLog("Output folder: " + outputFolder);
             AddLog("Creating archive: " + Path.GetFileName(archivePath));
 
             ttarch2BuilderLegacy1132(
@@ -96,8 +129,8 @@ namespace TTG_Tools
                 pokerNightProfile.NewEngineLua,
                 new HashSet<string>(StringComparer.OrdinalIgnoreCase)
                 {
-                    archivePath,
-                    luaPath
+                    Path.GetFullPath(archivePath),
+                    Path.GetFullPath(luaPath)
                 });
 
             AddLog("Generating Lua descriptor: " + Path.GetFileName(luaPath));
@@ -145,8 +178,51 @@ namespace TTG_Tools
             inputFolderTextBox.Enabled = enabled;
             browseInputButton.Enabled = enabled;
             modNameTextBox.Enabled = enabled;
+            outputFolderTextBox.Enabled = enabled;
+            browseOutputButton.Enabled = enabled;
             createModButton.Enabled = enabled;
             gameComboBox.Enabled = false;
+        }
+
+
+        private void InputFolder_DragEnter(object sender, DragEventArgs e)
+        {
+            if (e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                string[] paths = (string[])e.Data.GetData(DataFormats.FileDrop);
+                if (paths != null && paths.Length > 0 && Directory.Exists(paths[0]))
+                {
+                    e.Effect = DragDropEffects.Copy;
+                    return;
+                }
+            }
+
+            e.Effect = DragDropEffects.None;
+        }
+
+        private void InputFolder_DragDrop(object sender, DragEventArgs e)
+        {
+            if (!e.Data.GetDataPresent(DataFormats.FileDrop))
+            {
+                return;
+            }
+
+            string[] paths = (string[])e.Data.GetData(DataFormats.FileDrop);
+            if (paths == null || paths.Length == 0)
+            {
+                return;
+            }
+
+            string droppedPath = paths[0];
+            if (Directory.Exists(droppedPath))
+            {
+                inputFolderTextBox.Text = droppedPath;
+
+                if (string.IsNullOrWhiteSpace(outputFolderTextBox.Text))
+                {
+                    outputFolderTextBox.Text = Path.Combine(droppedPath, "ModCreator_Output");
+                }
+            }
         }
 
         private static void ttarch2BuilderLegacy1132(
@@ -162,7 +238,7 @@ namespace TTG_Tools
         {
             DirectoryInfo di = new DirectoryInfo(inputFolder);
             FileInfo[] fi = di.GetFiles("*", SearchOption.AllDirectories)
-                .Where(f => excludedPaths == null || !excludedPaths.Contains(f.FullName))
+                .Where(f => excludedPaths == null || !excludedPaths.Contains(Path.GetFullPath(f.FullName)))
                 .GroupBy(f => f.Name)
                 .Select(g => g.First())
                 .ToArray();
@@ -368,6 +444,11 @@ namespace TTG_Tools
             public string BuildArchiveFileName(string modName)
             {
                 return "CP_pc_" + modName + ".ttarch2";
+            }
+
+            public string BuildLuaFileName(string modName)
+            {
+                return "_resdesc_50_" + modName + ".lua";
             }
 
             public string BuildLuaDescriptor(string modName, string archiveFileName)

--- a/master/ModCreator.cs
+++ b/master/ModCreator.cs
@@ -1,0 +1,408 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Microsoft.WindowsAPICodePack.Dialogs;
+
+namespace TTG_Tools
+{
+    public partial class ModCreator : Form
+    {
+        private readonly CommonOpenFileDialog folderDialog = new CommonOpenFileDialog();
+        private readonly PokerNightRemasterProfile pokerNightProfile = new PokerNightRemasterProfile();
+
+        public ModCreator()
+        {
+            InitializeComponent();
+            folderDialog.IsFolderPicker = true;
+            folderDialog.EnsurePathExists = true;
+        }
+
+        private void ModCreator_Load(object sender, EventArgs e)
+        {
+            gameComboBox.Items.Clear();
+            gameComboBox.Items.Add(pokerNightProfile.GameDisplayName);
+            gameComboBox.SelectedIndex = 0;
+            gameComboBox.Enabled = false; // estrutura preparada, mas bloqueada para este jogo nesta fase.
+        }
+
+        private void browseInputButton_Click(object sender, EventArgs e)
+        {
+            if (folderDialog.ShowDialog() == CommonFileDialogResult.Ok)
+            {
+                inputFolderTextBox.Text = folderDialog.FileName;
+            }
+        }
+
+        private async void createModButton_Click(object sender, EventArgs e)
+        {
+            string inputFolder = inputFolderTextBox.Text.Trim();
+            string modName = NormalizeModName(modNameTextBox.Text.Trim());
+
+            if (!Directory.Exists(inputFolder))
+            {
+                MessageBox.Show("Input folder doesn't exist.", "Error");
+                return;
+            }
+
+            if (string.IsNullOrWhiteSpace(modName))
+            {
+                MessageBox.Show("Please provide a valid mod name.", "Error");
+                return;
+            }
+
+            string archiveFileName = pokerNightProfile.BuildArchiveFileName(modName);
+            string archivePath = Path.Combine(inputFolder, archiveFileName);
+            string luaPath = Path.Combine(inputFolder, modName + ".lua");
+
+            SetUiEnabled(false);
+            logListBox.Items.Clear();
+            AddLog("Starting mod creation for Poker Night at the Inventory - Remastered...");
+
+            try
+            {
+                await Task.Run(() => CreateModPackage(inputFolder, archivePath, luaPath, modName, archiveFileName));
+                AddLog("Mod created successfully.");
+                MessageBox.Show("Mod created successfully.", "Success");
+            }
+            catch (Exception ex)
+            {
+                AddLog("Error: " + ex.Message);
+                MessageBox.Show("Failed to create mod. Check logs for details.", "Error");
+            }
+            finally
+            {
+                SetUiEnabled(true);
+            }
+        }
+
+        private void CreateModPackage(string inputFolder, string archivePath, string luaPath, string modName, string archiveFileName)
+        {
+            byte[] gameKey = GetEncryptionKeyForGame(pokerNightProfile.GameDisplayName);
+
+            AddLog("Creating archive: " + Path.GetFileName(archivePath));
+
+            ttarch2BuilderLegacy1132(
+                inputFolder,
+                archivePath,
+                pokerNightProfile.CompressArchive,
+                pokerNightProfile.EncryptArchive,
+                pokerNightProfile.EncryptLuaInsideArchive,
+                gameKey,
+                pokerNightProfile.Ttarch2Version,
+                pokerNightProfile.NewEngineLua,
+                new HashSet<string>(StringComparer.OrdinalIgnoreCase)
+                {
+                    archivePath,
+                    luaPath
+                });
+
+            AddLog("Generating Lua descriptor: " + Path.GetFileName(luaPath));
+            string luaContent = pokerNightProfile.BuildLuaDescriptor(modName, archiveFileName);
+
+            File.WriteAllText(luaPath, luaContent, new UTF8Encoding(false));
+
+            AddLog("Encrypting Lua descriptor in-place (Lua Scripts for New Engine / method 7-9)...");
+            byte[] encryptedLua = Methods.encryptLua(File.ReadAllBytes(luaPath), gameKey, pokerNightProfile.NewEngineLua, 7);
+            File.WriteAllBytes(luaPath, encryptedLua);
+        }
+
+        private static string NormalizeModName(string modName)
+        {
+            char[] invalid = Path.GetInvalidFileNameChars();
+            return new string(modName.Where(c => !invalid.Contains(c)).ToArray()).Trim();
+        }
+
+        private static byte[] GetEncryptionKeyForGame(string gameName)
+        {
+            var gameKey = MainMenu.gamelist.FirstOrDefault(g => g.gamename == gameName);
+            if (gameKey == null || gameKey.key == null)
+            {
+                throw new InvalidOperationException("Could not find encryption key for selected game.");
+            }
+
+            return gameKey.key;
+        }
+
+        private void AddLog(string text)
+        {
+            if (InvokeRequired)
+            {
+                Invoke(new Action<string>(AddLog), text);
+                return;
+            }
+
+            logListBox.Items.Add(text);
+            logListBox.SelectedIndex = logListBox.Items.Count - 1;
+            logListBox.SelectedIndex = -1;
+        }
+
+        private void SetUiEnabled(bool enabled)
+        {
+            inputFolderTextBox.Enabled = enabled;
+            browseInputButton.Enabled = enabled;
+            modNameTextBox.Enabled = enabled;
+            createModButton.Enabled = enabled;
+            gameComboBox.Enabled = false;
+        }
+
+        private static void ttarch2BuilderLegacy1132(
+            string inputFolder,
+            string outputPath,
+            bool compression,
+            bool encryption,
+            bool encLua,
+            byte[] key,
+            int versionArchive,
+            bool newEngine,
+            ISet<string> excludedPaths)
+        {
+            DirectoryInfo di = new DirectoryInfo(inputFolder);
+            FileInfo[] fi = di.GetFiles("*", SearchOption.AllDirectories)
+                .Where(f => excludedPaths == null || !excludedPaths.Contains(f.FullName))
+                .GroupBy(f => f.Name)
+                .Select(g => g.First())
+                .ToArray();
+
+            ulong[] nameCrc = new ulong[fi.Length];
+            string[] name = new string[fi.Length];
+            ulong offset = 0;
+
+            for (int i = 0; i < fi.Length; i++)
+            {
+                if ((fi[i].Extension.ToLower() == ".lua") && encLua)
+                {
+                    name[i] = !newEngine ? fi[i].Name.Replace(".lua", ".lenc") : fi[i].Name;
+                }
+                else
+                {
+                    name[i] = fi[i].Name;
+                }
+                nameCrc[i] = CRCs.CRC64(0, name[i].ToLower());
+            }
+
+            for (int i = 0; i < fi.Length - 1; i++)
+            {
+                for (int j = i + 1; j < fi.Length; j++)
+                {
+                    if (nameCrc[j] < nameCrc[i])
+                    {
+                        FileInfo tempFi = fi[i];
+                        fi[i] = fi[j];
+                        fi[j] = tempFi;
+
+                        ulong tempCrc = nameCrc[i];
+                        nameCrc[i] = nameCrc[j];
+                        nameCrc[j] = tempCrc;
+
+                        string tempName = name[i];
+                        name[i] = name[j];
+                        name[j] = tempName;
+                    }
+                }
+            }
+
+            uint nameSize = 0;
+            for (int i = 0; i < fi.Length; i++)
+            {
+                nameSize += (uint)name[i].Length + 1;
+            }
+
+            ulong infoSize = (ulong)fi.Length * 28;
+            uint dataSize = 0;
+            for (int i = 0; i < fi.Length; i++)
+            {
+                dataSize += (uint)fi[i].Length;
+            }
+
+            ulong commonSize = infoSize + nameSize + dataSize + 24;
+            byte[] ncttHeader = Encoding.ASCII.GetBytes("NCTT");
+            byte[] att = { 65, 84, 84, 84 };
+            byte[] infoTable = new byte[infoSize];
+            byte[] namesTable = new byte[nameSize];
+
+            uint fileOffset = 0;
+            uint ns = 0;
+
+            for (int k = 0; k < fi.Length; k++)
+            {
+                byte[] tmpName = Encoding.ASCII.GetBytes(name[k]);
+                Array.Copy(tmpName, 0, namesTable, ns, tmpName.Length);
+                ns += (uint)tmpName.Length + 1;
+
+                Array.Copy(BitConverter.GetBytes(nameCrc[k]), 0, infoTable, (long)offset, 8);
+                offset += 8;
+                Array.Copy(BitConverter.GetBytes((ulong)fileOffset), 0, infoTable, (long)offset, 8);
+                offset += 8;
+                Array.Copy(BitConverter.GetBytes((uint)fi[k].Length), 0, infoTable, (long)offset, 4);
+                offset += 4;
+                Array.Copy(BitConverter.GetBytes(0), 0, infoTable, (long)offset, 4);
+                offset += 4;
+
+                uint tmp = ns - nameSize;
+                Array.Copy(BitConverter.GetBytes((ushort)(tmp / 0x10000)), 0, infoTable, (long)offset, 2);
+                offset += 2;
+                Array.Copy(BitConverter.GetBytes((ushort)(tmp % 0x10000)), 0, infoTable, (long)offset, 2);
+                offset += 2;
+                fileOffset += (uint)fi[k].Length;
+            }
+
+            string format = Methods.GetExtension(outputPath).ToLower() == ".obb" ? ".obb" : ".ttarch2";
+            string tempPath = outputPath.Replace(format, ".tmp");
+
+            using (FileStream fs = new FileStream(tempPath, FileMode.Create))
+            {
+                fs.Write(ncttHeader, 0, 4);
+                fs.Write(BitConverter.GetBytes(commonSize), 0, 8);
+                fs.Write(att, 0, 4);
+
+                if (versionArchive == 1)
+                {
+                    fs.Write(BitConverter.GetBytes(2), 0, 4);
+                }
+
+                fs.Write(BitConverter.GetBytes(nameSize), 0, 4);
+                fs.Write(BitConverter.GetBytes(fi.Length), 0, 4);
+                fs.Write(infoTable, 0, (int)infoSize);
+                fs.Write(namesTable, 0, (int)nameSize);
+
+                for (int l = 0; l < fi.Length; l++)
+                {
+                    byte[] file = File.ReadAllBytes(fi[l].FullName);
+
+                    if ((fi[l].Extension.ToLower() == ".lua") && encLua)
+                    {
+                        file = Methods.encryptLua(file, key, newEngine, 7);
+                    }
+
+                    fs.Write(file, 0, file.Length);
+                }
+            }
+
+            if (!compression)
+            {
+                if (File.Exists(outputPath)) File.Delete(outputPath);
+                File.Move(tempPath, outputPath);
+                return;
+            }
+
+            using (FileStream fs = new FileStream(outputPath, FileMode.Create))
+            using (FileStream tempFr = new FileStream(tempPath, FileMode.Open))
+            {
+                ulong fullIt = Methods.pad_it(commonSize, 0x10000);
+                uint blocksCount = (uint)fullIt / 0x10000;
+                byte[] compressedHeader = encryption ? Encoding.ASCII.GetBytes("ECTT") : Encoding.ASCII.GetBytes("ZCTT");
+                byte[] chunkSize = { 0x00, 0x00, 0x01, 0x00 };
+                ulong chunkTableSize = 8 * blocksCount + 8;
+                offset = chunkTableSize + 12;
+                byte[] chunkTable = new byte[chunkTableSize];
+
+                Array.Copy(BitConverter.GetBytes(offset), 0, chunkTable, 0, 8);
+
+                fs.Write(compressedHeader, 0, compressedHeader.Length);
+                fs.Write(chunkSize, 0, 4);
+                fs.Write(BitConverter.GetBytes(blocksCount), 0, 4);
+                fs.Write(chunkTable, 0, chunkTable.Length);
+
+                tempFr.Seek(12, SeekOrigin.Begin);
+
+                for (int i = 0; i < blocksCount; i++)
+                {
+                    byte[] temp = new byte[0x10000];
+                    tempFr.Read(temp, 0, temp.Length);
+                    byte[] compressedBlock = DeflateCompressor(temp);
+
+                    if (encryption)
+                    {
+                        compressedBlock = encryptFunction(compressedBlock, key, 7);
+                    }
+
+                    offset += (uint)compressedBlock.Length;
+                    Array.Copy(BitConverter.GetBytes(offset), 0, chunkTable, 8 + (i * 8), 8);
+                    fs.Write(compressedBlock, 0, compressedBlock.Length);
+                }
+
+                fs.Seek(12, SeekOrigin.Begin);
+                fs.Write(chunkTable, 0, chunkTable.Length);
+            }
+
+            File.Delete(tempPath);
+        }
+
+        private static byte[] DeflateCompressor(byte[] bytes)
+        {
+            byte[] retVal;
+            using (MemoryStream compressedMemoryStream = new MemoryStream())
+            {
+                using (System.IO.Compression.DeflateStream compressStream = new System.IO.Compression.DeflateStream(compressedMemoryStream, System.IO.Compression.CompressionMode.Compress))
+                {
+                    using (MemoryStream inMemStream = new MemoryStream(bytes))
+                    {
+                        inMemStream.CopyTo(compressStream);
+                        compressStream.Close();
+                        retVal = compressedMemoryStream.ToArray();
+                    }
+                }
+            }
+            return retVal;
+        }
+
+        private static byte[] encryptFunction(byte[] bytes, byte[] key, int archiveVersion)
+        {
+            BlowFishCS.BlowFish enc = new BlowFishCS.BlowFish(key, archiveVersion);
+            return enc.Crypt_ECB(bytes, archiveVersion, false);
+        }
+
+        private class PokerNightRemasterProfile
+        {
+            public string GameDisplayName => "Poker Night at the Inventory - Remastered";
+            public bool CompressArchive => true;
+            public bool EncryptArchive => true;
+            public bool EncryptLuaInsideArchive => true;
+            public bool NewEngineLua => true;
+            public int Ttarch2Version => 2;
+
+            public string BuildArchiveFileName(string modName)
+            {
+                return "CP_pc_" + modName + ".ttarch2";
+            }
+
+            public string BuildLuaDescriptor(string modName, string archiveFileName)
+            {
+                StringBuilder sb = new StringBuilder();
+                sb.AppendLine("local set = {}");
+                sb.AppendLine("set.name = \"" + modName + "\"");
+                sb.AppendLine("set.setName = \"" + modName + "\"");
+                sb.AppendLine("set.descriptionFilenameOverride = \"\"");
+                sb.AppendLine("set.logicalName = \"<Project>\"");
+                sb.AppendLine("set.logicalDestination = \"<>\"");
+                sb.AppendLine("set.priority = -8888");
+                sb.AppendLine("set.localDir = _currentDirectory");
+                sb.AppendLine("set.enableMode = \"constant\"");
+                sb.AppendLine("set.version = \"trunk\"");
+                sb.AppendLine("set.descriptionPriority = 0");
+                sb.AppendLine("set.gameDataName = \"" + modName + " Game Data\"");
+                sb.AppendLine("set.gameDataPriority = 0");
+                sb.AppendLine("set.gameDataEnableMode = \"constant\"");
+                sb.AppendLine("set.localDirIncludeBase = true");
+                sb.AppendLine("set.localDirRecurse = false");
+                sb.AppendLine("set.localDirIncludeOnly = nil");
+                sb.AppendLine("set.localDirExclude =");
+                sb.AppendLine("{");
+                sb.AppendLine("    \"Packaging/\",");
+                sb.AppendLine("    \"_dev/\"");
+                sb.AppendLine("}");
+                sb.AppendLine("set.gameDataArchives =");
+                sb.AppendLine("{");
+                sb.AppendLine("    _currentDirectory .. \"" + archiveFileName + "\"");
+                sb.AppendLine("}");
+                sb.AppendLine("RegisterSetDescription(set)");
+
+                return sb.ToString();
+            }
+        }
+    }
+}

--- a/master/TTG Tools.csproj
+++ b/master/TTG Tools.csproj
@@ -170,6 +170,12 @@
     <Compile Include="MainMenu.Designer.cs">
       <DependentUpon>MainMenu.cs</DependentUpon>
     </Compile>
+    <Compile Include="ModCreator.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="ModCreator.Designer.cs">
+      <DependentUpon>ModCreator.cs</DependentUpon>
+    </Compile>
     <Compile Include="Methods.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
### Motivation
- Provide a built-in Mod Creator to package mods (archive + encrypted Lua descriptor) for "Poker Night at the Inventory - Remastered" and expose it from the main menu.

### Description
- Add a new `ModCreator` form with designer (`ModCreator.cs`, `ModCreator.Designer.cs`) that provides input folder selection, mod name entry, game selection, log output and a `Create` action.
- Implement mod packaging flow in `ModCreator.cs` including mod name normalization, manifest (`.lua`) generation, in-place Lua encryption, archive building (`ttarch2BuilderLegacy1132`) with optional compression and encryption, and helper functions for compression and encryption.
- Integrate the new tool into the main menu by adding a `modCreatorBtn` in `MainMenu.Designer.cs` and a `modCreatorBtn_Click` handler in `MainMenu.cs`.
- Update the project file (`TTG Tools.csproj`) to include the new source and designer files so the project builds with the Mod Creator included.