### PR TITLE
Handle TTARCH2 extraction errors gracefully and report failed files

### DIFF
--- a/master/ArchiveUnpacker.cs
+++ b/master/ArchiveUnpacker.cs
@@ -800,7 +800,10 @@ namespace TTG_Tools
                                 {
                                     byte[] tmp = getTtarch2File(ttarch2, ttarch2.files[i], key, br);
 
-                                    ttarch2.isEncryptedLua = Methods.isLuaEncrypted(tmp);
+                                    if (tmp != null)
+                                    {
+                                        ttarch2.isEncryptedLua = Methods.isLuaEncrypted(tmp);
+                                    }
                                 }
                             }
 
@@ -827,6 +830,7 @@ namespace TTG_Tools
         private void UnpackTtarch2(string folderPath, string format, int[] indexes = null)
         {
             var files = getFilteredTtarch2Files();
+            List<string> failedFiles = new List<string>();
 
             int count = indexes != null ? indexes.Length : files.Length;
             
@@ -843,6 +847,14 @@ namespace TTG_Tools
                 byte[] file = getTtarch2File(ttarch2, files[ind], key, br);
 
                 string fileName = files[ind].fileName;
+
+                if (file == null)
+                {
+                    failedFiles.Add(fileName);
+                    Progress(i + 1);
+                    continue;
+                }
+
                 if (((fileName.Substring(fileName.Length - 5, 5).ToLower() == ".lenc") || (fileName.Substring(fileName.Length - 4, 4).ToLower() == ".lua")) && decrypt)
                 {
                     fileName = fileName.Substring(fileName.Length - 5, 5).ToLower() == ".lenc" ? fileName.Remove(fileName.Length - 4, 4) + "lua" : fileName.Remove(fileName.Length - 3, 3) + "lua";
@@ -856,6 +868,11 @@ namespace TTG_Tools
 
             br.Close();
             fs.Close();
+
+            if (failedFiles.Count > 0)
+            {
+                MessageBox.Show("Não foi possível extrair os seguintes arquivos:\n\n" + string.Join("\n", failedFiles), "Arquivos não extraídos", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            }
         }
 
         private void getArchiveInfo()
@@ -1137,8 +1154,6 @@ namespace TTG_Tools
 
                             if (tmp == null || tmp.Length == 0)
                             {
-                                MessageBox.Show("TTG Tools couldn't decompress block. Compress algorithm is " + Convert.ToString(ttarch2.compressAlgorithm), "Decompress error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-
                                 br.Close();
                                 return null;
                             }


### PR DESCRIPTION
### Motivation
- Prevent the application from crashing when a TTARCH2 compressed block cannot be decompressed and a `null` byte array would otherwise be written to disk. 
- Allow extraction to continue for the rest of the archive and surface which files failed instead of stopping with an unhandled exception. 
- Avoid probing Lua-encryption state with a `null` buffer during archive inspection which can cause an exception. 

### Description
- Added a null-check before calling `Methods.isLuaEncrypted(tmp)` when probing files during TTARCH2 header parsing so a `null` `tmp` is ignored. 
- In `UnpackTtarch2`, added a `List<string> failedFiles` to collect names of files that could not be extracted. 
- If `getTtarch2File(...)` returns `null` for a file, the code now records the file name, advances progress, and continues instead of calling `File.WriteAllBytes` with `null`. 
- At the end of `UnpackTtarch2`, the tool shows a single warning `MessageBox` listing the files that failed to extract so the user can retry or investigate. 
- Removed the immediate per-block decompression popup so `getTtarch2File` can return `null` and allow the caller to handle/report failures centrally.