### PR TITLE
Bump TTG Tools to v1.15.9 and add changelog entry

### DIFF
--- a/master/About.resx
+++ b/master/About.resx
@@ -147,6 +147,12 @@ Maybe some games doesn't work.
 ===
 [Version history]
 
+v.1.15.9 (16.03.2026)
++ TTG Tools:
+Added a Mod Creator.
++ Mod Creator:
+Initial support for Poker Night at the Inventory - Remastered and Sam &amp; Max: Save the World - Remastered.
+
 v.1.15.8 (08.03.2026)
 + TTG Tools:
 Added support for the game Poker Night at the Inventory - Remastered.

--- a/master/Properties/AssemblyInfo.cs
+++ b/master/Properties/AssemblyInfo.cs
@@ -33,6 +33,6 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.15.8.0")]
-[assembly: AssemblyFileVersion("1.15.8.0")]
+[assembly: AssemblyVersion("1.15.9.0")]
+[assembly: AssemblyFileVersion("1.15.9.0")]
 [assembly: NeutralResourcesLanguage("en")]


### PR DESCRIPTION
### Motivation
- Bump the public version to `v.1.15.9` and record the new Mod Creator feature and its initial game support in the user-facing changelog.

### Description
- Updated assembly version and file version to `1.15.9.0` in `master/Properties/AssemblyInfo.cs`.
- Added a `v.1.15.9 (16.03.2026)` changelog entry under `[Version history]` in `master/About.resx` describing `TTG Tools: Added a Mod Creator.` and `Mod Creator: Initial support for Poker Night at the Inventory - Remastered and Sam & Max: Save the World - Remastered.`