### PR TITLE
Add support for Wii files (ERTM/TPL) for fonts and textures

### DIFF
--- a/master/AutoPacker.Designer.cs
+++ b/master/AutoPacker.Designer.cs
@@ -39,6 +39,7 @@
             this.rbPS4Swizzle = new System.Windows.Forms.RadioButton();
             this.rbXbox360Swizzle = new System.Windows.Forms.RadioButton();
             this.rbPSVitaSwizzle = new System.Windows.Forms.RadioButton();
+            this.rbWiiSwizzle = new System.Windows.Forms.RadioButton();
             this.rbNoSwizzle = new System.Windows.Forms.RadioButton();
             this.labelUnicode = new System.Windows.Forms.Label();
             this.checkIOS = new System.Windows.Forms.CheckBox();
@@ -140,10 +141,11 @@
             this.groupBox2.Controls.Add(this.rbPS4Swizzle);
             this.groupBox2.Controls.Add(this.rbXbox360Swizzle);
             this.groupBox2.Controls.Add(this.rbPSVitaSwizzle);
+            this.groupBox2.Controls.Add(this.rbWiiSwizzle);
             this.groupBox2.Controls.Add(this.rbNoSwizzle);
             this.groupBox2.Location = new System.Drawing.Point(276, 15);
             this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(126, 130);
+            this.groupBox2.Size = new System.Drawing.Size(126, 152);
             this.groupBox2.TabIndex = 17;
             this.groupBox2.TabStop = false;
             this.groupBox2.Text = "Swizzle methods";
@@ -195,6 +197,19 @@
             this.rbPSVitaSwizzle.Text = "PS Vita";
             this.rbPSVitaSwizzle.UseVisualStyleBackColor = true;
             this.rbPSVitaSwizzle.CheckedChanged += new System.EventHandler(this.rbPSVitaSwizzle_CheckedChanged);
+            // 
+            // 
+            // rbWiiSwizzle
+            // 
+            this.rbWiiSwizzle.AutoSize = true;
+            this.rbWiiSwizzle.Location = new System.Drawing.Point(16, 129);
+            this.rbWiiSwizzle.Name = "rbWiiSwizzle";
+            this.rbWiiSwizzle.Size = new System.Drawing.Size(84, 17);
+            this.rbWiiSwizzle.TabIndex = 5;
+            this.rbWiiSwizzle.TabStop = true;
+            this.rbWiiSwizzle.Text = "Nintendo Wii";
+            this.rbWiiSwizzle.UseVisualStyleBackColor = true;
+            this.rbWiiSwizzle.CheckedChanged += new System.EventHandler(this.rbWiiSwizzle_CheckedChanged);
             // 
             // rbNoSwizzle
             // 
@@ -403,6 +418,7 @@
         private System.Windows.Forms.RadioButton rbPS4Swizzle;
         private System.Windows.Forms.RadioButton rbXbox360Swizzle;
         private System.Windows.Forms.RadioButton rbPSVitaSwizzle;
+        private System.Windows.Forms.RadioButton rbWiiSwizzle;
         private System.Windows.Forms.RadioButton rbNoSwizzle;
         private System.Windows.Forms.Label sortLabel;
     }

--- a/master/AutoPacker.cs
+++ b/master/AutoPacker.cs
@@ -211,12 +211,13 @@ namespace TTG_Tools
             checkEncLangdb.Checked = MainMenu.settings.encLangdb;
             CheckNewEngine.Checked = MainMenu.settings.encNewLua;
 
-            if (MainMenu.settings.swizzlePS4 || MainMenu.settings.swizzleNintendoSwitch || MainMenu.settings.swizzleXbox360 || MainMenu.settings.swizzlePSVita)
+            if (MainMenu.settings.swizzlePS4 || MainMenu.settings.swizzleNintendoSwitch || MainMenu.settings.swizzleXbox360 || MainMenu.settings.swizzlePSVita || MainMenu.settings.swizzleNintendoWii)
             {
                 if (MainMenu.settings.swizzleNintendoSwitch) rbSwitchSwizzle.Checked = true;
                 else if (MainMenu.settings.swizzlePS4) rbPS4Swizzle.Checked = true;
                 else if (MainMenu.settings.swizzleXbox360) rbXbox360Swizzle.Checked = true;
                 else if (MainMenu.settings.swizzlePSVita) rbPSVitaSwizzle.Checked = true;
+                else if (MainMenu.settings.swizzleNintendoWii) rbWiiSwizzle.Checked = true;
             }
             else rbNoSwizzle.Checked = true;
 
@@ -343,6 +344,7 @@ namespace TTG_Tools
                 MainMenu.settings.swizzlePS4 = false;
                 MainMenu.settings.swizzleXbox360 = false;
                 MainMenu.settings.swizzlePSVita = false;
+                MainMenu.settings.swizzleNintendoWii = false;
                 Settings.SaveConfig(MainMenu.settings);
             }
         }
@@ -355,6 +357,7 @@ namespace TTG_Tools
                 MainMenu.settings.swizzleNintendoSwitch = false;
                 MainMenu.settings.swizzleXbox360 = false;
                 MainMenu.settings.swizzlePSVita = false;
+                MainMenu.settings.swizzleNintendoWii = false;
                 Settings.SaveConfig(MainMenu.settings);
             }
         }
@@ -367,6 +370,7 @@ namespace TTG_Tools
                 MainMenu.settings.swizzlePS4 = false;
                 MainMenu.settings.swizzleXbox360 = false;
                 MainMenu.settings.swizzlePSVita = false;
+                MainMenu.settings.swizzleNintendoWii = false;
                 Settings.SaveConfig(MainMenu.settings);
             }
         }
@@ -379,6 +383,7 @@ namespace TTG_Tools
                 MainMenu.settings.swizzlePS4 = false;
                 MainMenu.settings.swizzleNintendoSwitch = false;
                 MainMenu.settings.swizzlePSVita = false;
+                MainMenu.settings.swizzleNintendoWii = false;
                 Settings.SaveConfig(MainMenu.settings);
             }
         }
@@ -391,6 +396,21 @@ namespace TTG_Tools
                 MainMenu.settings.swizzlePS4 = false;
                 MainMenu.settings.swizzleNintendoSwitch = false;
                 MainMenu.settings.swizzleXbox360 = false;
+                MainMenu.settings.swizzleNintendoWii = false;
+                Settings.SaveConfig(MainMenu.settings);
+            }
+        }
+
+
+        private void rbWiiSwizzle_CheckedChanged(object sender, EventArgs e)
+        {
+            if (rbWiiSwizzle.Checked)
+            {
+                MainMenu.settings.swizzlePSVita = false;
+                MainMenu.settings.swizzlePS4 = false;
+                MainMenu.settings.swizzleNintendoSwitch = false;
+                MainMenu.settings.swizzleXbox360 = false;
+                MainMenu.settings.swizzleNintendoWii = true;
                 Settings.SaveConfig(MainMenu.settings);
             }
         }

--- a/master/FontEditor.Designer.cs
+++ b/master/FontEditor.Designer.cs
@@ -91,6 +91,7 @@
             this.rbPS4Swizzle = new System.Windows.Forms.RadioButton();
             this.rbXbox360Swizzle = new System.Windows.Forms.RadioButton();
             this.rbPSVitaSwizzle = new System.Windows.Forms.RadioButton();
+            this.rbWiiSwizzle = new System.Windows.Forms.RadioButton();
             this.rbNoSwizzle = new System.Windows.Forms.RadioButton();
             this.pictureBoxTexturePreview = new System.Windows.Forms.PictureBox();
             this.labelTexturePreview = new System.Windows.Forms.Label();
@@ -674,10 +675,11 @@
             this.groupBox4.Controls.Add(this.rbPS4Swizzle);
             this.groupBox4.Controls.Add(this.rbXbox360Swizzle);
             this.groupBox4.Controls.Add(this.rbPSVitaSwizzle);
+            this.groupBox4.Controls.Add(this.rbWiiSwizzle);
             this.groupBox4.Controls.Add(this.rbNoSwizzle);
             this.groupBox4.Location = new System.Drawing.Point(1005, 28);
             this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(122, 149);
+            this.groupBox4.Size = new System.Drawing.Size(122, 173);
             this.groupBox4.TabIndex = 30;
             this.groupBox4.TabStop = false;
             this.groupBox4.Text = "Swizzle methods";
@@ -729,6 +731,19 @@
             this.rbPSVitaSwizzle.Text = "PS Vita";
             this.rbPSVitaSwizzle.UseVisualStyleBackColor = true;
             this.rbPSVitaSwizzle.CheckedChanged += new System.EventHandler(this.rbPSVitaSwizzle_CheckedChanged);
+            // 
+            // 
+            // rbWiiSwizzle
+            // 
+            this.rbWiiSwizzle.AutoSize = true;
+            this.rbWiiSwizzle.Location = new System.Drawing.Point(7, 149);
+            this.rbWiiSwizzle.Name = "rbWiiSwizzle";
+            this.rbWiiSwizzle.Size = new System.Drawing.Size(84, 17);
+            this.rbWiiSwizzle.TabIndex = 5;
+            this.rbWiiSwizzle.TabStop = true;
+            this.rbWiiSwizzle.Text = "Nintendo Wii";
+            this.rbWiiSwizzle.UseVisualStyleBackColor = true;
+            this.rbWiiSwizzle.CheckedChanged += new System.EventHandler(this.rbWiiSwizzle_CheckedChanged);
             // 
             // rbNoSwizzle
             // 
@@ -853,6 +868,7 @@
         private System.Windows.Forms.RadioButton rbPS4Swizzle;
         private System.Windows.Forms.RadioButton rbXbox360Swizzle;
         private System.Windows.Forms.RadioButton rbPSVitaSwizzle;
+        private System.Windows.Forms.RadioButton rbWiiSwizzle;
         private System.Windows.Forms.RadioButton rbNoSwizzle;
         private System.Windows.Forms.DataGridViewTextBoxColumn Column1;
         private System.Windows.Forms.DataGridViewTextBoxColumn Column2;

--- a/master/FontEditor.cs
+++ b/master/FontEditor.cs
@@ -96,11 +96,12 @@ namespace TTG_Tools
         {
             edited = false; //Tell a program about first launch window form so font is not modified.
             
-            if(MainMenu.settings.swizzlePS4 || MainMenu.settings.swizzleNintendoSwitch || MainMenu.settings.swizzleXbox360 || MainMenu.settings.swizzlePSVita)
+            if(MainMenu.settings.swizzlePS4 || MainMenu.settings.swizzleNintendoSwitch || MainMenu.settings.swizzleXbox360 || MainMenu.settings.swizzlePSVita || MainMenu.settings.swizzleNintendoWii)
             {
                 if (MainMenu.settings.swizzlePS4) rbPS4Swizzle.Checked = true;
                 else if (MainMenu.settings.swizzlePSVita) rbPSVitaSwizzle.Checked = true;
                 else if (MainMenu.settings.swizzleXbox360) rbXbox360Swizzle.Checked = true;
+                else if (MainMenu.settings.swizzleNintendoWii) rbWiiSwizzle.Checked = true;
                 else rbSwitchSwizzle.Checked = true;
             }
             else
@@ -1119,7 +1120,8 @@ namespace TTG_Tools
                     {
                     try
                     {
-                        if (Path.GetExtension(selectedFontPath).Equals(".font", StringComparison.OrdinalIgnoreCase)
+                        if (MainMenu.settings.swizzleNintendoWii
+                            && Path.GetExtension(selectedFontPath).Equals(".font", StringComparison.OrdinalIgnoreCase)
                             && Graphics.WiiSupport.TryLoadWiiFontForEditor(selectedFontPath, out wiiFontData))
                         {
                             fontFlags = null;
@@ -2918,6 +2920,7 @@ namespace TTG_Tools
             MainMenu.settings.swizzlePS4 = false;
             MainMenu.settings.swizzleNintendoSwitch = false;
             MainMenu.settings.swizzlePSVita = false;
+            MainMenu.settings.swizzleNintendoWii = false;
             Settings.SaveConfig(MainMenu.settings);
         }
 
@@ -2927,6 +2930,7 @@ namespace TTG_Tools
             MainMenu.settings.swizzlePS4 = true;
             MainMenu.settings.swizzleNintendoSwitch = false;
             MainMenu.settings.swizzlePSVita = false;
+            MainMenu.settings.swizzleNintendoWii = false;
             Settings.SaveConfig(MainMenu.settings);
         }
 
@@ -2936,6 +2940,7 @@ namespace TTG_Tools
             MainMenu.settings.swizzlePS4 = false;
             MainMenu.settings.swizzleNintendoSwitch = true;
             MainMenu.settings.swizzlePSVita = false;
+            MainMenu.settings.swizzleNintendoWii = false;
             Settings.SaveConfig(MainMenu.settings);
         }
 
@@ -2947,6 +2952,7 @@ namespace TTG_Tools
                 MainMenu.settings.swizzlePS4 = false;
                 MainMenu.settings.swizzleNintendoSwitch = false;
                 MainMenu.settings.swizzlePSVita = false;
+                MainMenu.settings.swizzleNintendoWii = false;
                 Settings.SaveConfig(MainMenu.settings);
             }
         }
@@ -2959,6 +2965,21 @@ namespace TTG_Tools
                 MainMenu.settings.swizzlePS4 = false;
                 MainMenu.settings.swizzleNintendoSwitch = false;
                 MainMenu.settings.swizzleXbox360 = false;
+                MainMenu.settings.swizzleNintendoWii = false;
+                Settings.SaveConfig(MainMenu.settings);
+            }
+        }
+
+
+        private void rbWiiSwizzle_CheckedChanged(object sender, EventArgs e)
+        {
+            if (rbWiiSwizzle.Checked)
+            {
+                MainMenu.settings.swizzlePSVita = false;
+                MainMenu.settings.swizzlePS4 = false;
+                MainMenu.settings.swizzleNintendoSwitch = false;
+                MainMenu.settings.swizzleXbox360 = false;
+                MainMenu.settings.swizzleNintendoWii = true;
                 Settings.SaveConfig(MainMenu.settings);
             }
         }

--- a/master/FontEditor.cs
+++ b/master/FontEditor.cs
@@ -39,6 +39,7 @@ namespace TTG_Tools
         bool AddInfo;
         string droppedFontPath;
         private Bitmap basePreviewBitmap;
+        private Graphics.WiiSupport.WiiFontData wiiFontData;
 
         private void EnableDragDropForControls(Control parent)
         {
@@ -1118,6 +1119,68 @@ namespace TTG_Tools
                     {
                     try
                     {
+                        if (Path.GetExtension(selectedFontPath).Equals(".font", StringComparison.OrdinalIgnoreCase)
+                            && Graphics.WiiSupport.TryLoadWiiFontForEditor(selectedFontPath, out wiiFontData))
+                        {
+                            fontFlags = null;
+                            font = new FontClass.ClassFont();
+                            font.NewFormat = false;
+                            font.blockSize = wiiFontData.IsBlockSizeFont;
+                            font.hasScaleValue = wiiFontData.HasScaleValue;
+                            font.FontName = wiiFontData.FontName;
+                            font.BaseSize = wiiFontData.BaseSize;
+                            font.TexCount = Math.Max(1, wiiFontData.TexCount);
+                            font.glyph.CharCount = wiiFontData.CharCount;
+                            font.glyph.chars = new FontClass.ClassFont.TRect[font.glyph.CharCount];
+
+                            int maxTex = 0;
+                            for (int i = 0; i < wiiFontData.Glyphs.Count; i++)
+                            {
+                                var g = wiiFontData.Glyphs[i];
+                                maxTex = Math.Max(maxTex, g.TexNum);
+                                font.glyph.chars[i] = new FontClass.ClassFont.TRect
+                                {
+                                    TexNum = g.TexNum,
+                                    XStart = g.XStart,
+                                    XEnd = g.XEnd,
+                                    YStart = g.YStart,
+                                    YEnd = g.YEnd,
+                                    CharWidth = g.CharWidth,
+                                    CharHeight = g.CharHeight
+                                };
+                            }
+
+                            font.TexCount = Math.Max(font.TexCount, maxTex + 1);
+                            font.tex = new TextureClass.OldT3Texture[font.TexCount];
+                            for (int i = 0; i < font.TexCount; i++)
+                            {
+                                font.tex[i] = new TextureClass.OldT3Texture
+                                {
+                                    Width = wiiFontData.TextureWidth,
+                                    Height = wiiFontData.TextureHeight,
+                                    OriginalWidth = wiiFontData.TextureWidth,
+                                    OriginalHeight = wiiFontData.TextureHeight,
+                                    TexSize = 0,
+                                    Content = new byte[0]
+                                };
+                            }
+
+                            check_header = Encoding.ASCII.GetBytes("ERTM");
+                            fillTableofCoordinates(font, false);
+                            fillTableofTextures(font);
+                            UpdateTexturePreview();
+                            saveToolStripMenuItem.Enabled = true;
+                            saveAsToolStripMenuItem.Enabled = true;
+                            exportCoordinatesToolStripMenuItem1.Enabled = true;
+                            rbKerning.Enabled = false;
+                            rbNoKerning.Enabled = false;
+                            edited = false;
+                            FileInfo fiWii = new FileInfo(FileName);
+                            if (Form.ActiveForm != null) Form.ActiveForm.Text = "Font Editor. Opened file " + fiWii.Name + " (Wii)";
+                            return;
+                        }
+
+                        wiiFontData = null;
                         fontFlags = null;
 
                         byte[] header = new byte[4];
@@ -1683,6 +1746,28 @@ namespace TTG_Tools
 
         private void SaveFont(Stream fs, ClassesStructs.FontClass.ClassFont font)
         {
+            if (wiiFontData != null)
+            {
+                fs.Close();
+                for (int i = 0; i < font.glyph.CharCount && i < wiiFontData.Glyphs.Count; i++)
+                {
+                    var src = font.glyph.chars[i];
+                    var dst = wiiFontData.Glyphs[i];
+                    dst.TexNum = src.TexNum;
+                    dst.XStart = src.XStart;
+                    dst.XEnd = src.XEnd;
+                    dst.YStart = src.YStart;
+                    dst.YEnd = src.YEnd;
+                    if (wiiFontData.HasScaleValue)
+                    {
+                        dst.CharWidth = src.CharWidth;
+                        dst.CharHeight = src.CharHeight;
+                    }
+                }
+                wiiFontData.Save(ofd.FileName);
+                return;
+            }
+
             BinaryWriter bw = new BinaryWriter(fs);
 
             bw.Write(tmpHeader);

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -107,6 +107,39 @@ namespace TTG_Tools
                                     fileDestination = inputFiles[i].Directory.GetFiles(onlyNameImporting + "(*)" + whatImport);
                                 }
 
+                                // Wii/TPL import support: Auto(De)Packer originally only watches
+                                // dds/pvr for textures and ttf for fonts. If user provides tpl/fnt,
+                                // we still need to trigger DoWork.
+                                if (fileDestination.Length == 0)
+                                {
+                                    if (destinationForExport == ".d3dtx")
+                                    {
+                                        string wiiPattern = q == 0
+                                            ? onlyNameImporting + ".tpl"
+                                            : onlyNameImporting + "(*)" + ".tpl";
+                                        fileDestination = inputFiles[i].Directory.GetFiles(wiiPattern);
+                                    }
+                                    else if (destinationForExport == ".font")
+                                    {
+                                        string tplPattern = q == 0
+                                            ? onlyNameImporting + ".tpl"
+                                            : onlyNameImporting + "(*)" + ".tpl";
+                                        string fntPattern = q == 0
+                                            ? onlyNameImporting + ".fnt"
+                                            : onlyNameImporting + "(*)" + ".fnt";
+
+                                        FileInfo[] tplCandidates = inputFiles[i].Directory.GetFiles(tplPattern);
+                                        if (tplCandidates.Length > 0)
+                                        {
+                                            fileDestination = tplCandidates;
+                                        }
+                                        else
+                                        {
+                                            fileDestination = inputFiles[i].Directory.GetFiles(fntPattern);
+                                        }
+                                    }
+                                }
+
                                 countOfAllFiles += fileDestination.Count();
 
                                 for (int j = 0; j < fileDestination.Length; j++)

--- a/master/ForThreads.cs
+++ b/master/ForThreads.cs
@@ -112,14 +112,14 @@ namespace TTG_Tools
                                 // we still need to trigger DoWork.
                                 if (fileDestination.Length == 0)
                                 {
-                                    if (destinationForExport == ".d3dtx")
+                                    if (destinationForExport == ".d3dtx" && whatImport == ".dds" && MainMenu.settings.swizzleNintendoWii)
                                     {
                                         string wiiPattern = q == 0
                                             ? onlyNameImporting + ".tpl"
                                             : onlyNameImporting + "(*)" + ".tpl";
                                         fileDestination = inputFiles[i].Directory.GetFiles(wiiPattern);
                                     }
-                                    else if (destinationForExport == ".font")
+                                    else if (destinationForExport == ".font" && MainMenu.settings.swizzleNintendoWii)
                                     {
                                         string tplPattern = q == 0
                                             ? onlyNameImporting + ".tpl"

--- a/master/Graphics/FontWorker.cs
+++ b/master/Graphics/FontWorker.cs
@@ -11,12 +11,12 @@ namespace TTG_Tools.Graphics
             FileInfo fi = new FileInfo(inputFile);
 
             string wiiResult;
-            if (extract && WiiSupport.TryExtractWiiContainer(inputFile, MainMenu.settings.pathForOutputFolder, out wiiResult))
+            if (MainMenu.settings.swizzleNintendoWii && extract && WiiSupport.TryExtractWiiContainer(inputFile, MainMenu.settings.pathForOutputFolder, out wiiResult))
             {
                 return wiiResult;
             }
 
-            if (!extract && WiiSupport.TryRepackWiiContainer(inputFile, fi.DirectoryName, MainMenu.settings.pathForOutputFolder, out wiiResult))
+            if (MainMenu.settings.swizzleNintendoWii && !extract && WiiSupport.TryRepackWiiContainer(inputFile, fi.DirectoryName, MainMenu.settings.pathForOutputFolder, out wiiResult))
             {
                 return wiiResult;
             }

--- a/master/Graphics/FontWorker.cs
+++ b/master/Graphics/FontWorker.cs
@@ -9,6 +9,18 @@ namespace TTG_Tools.Graphics
         public static string DoWork(string inputFile, bool extract)
         {
             FileInfo fi = new FileInfo(inputFile);
+
+            string wiiResult;
+            if (extract && WiiSupport.TryExtractWiiContainer(inputFile, MainMenu.settings.pathForOutputFolder, out wiiResult))
+            {
+                return wiiResult;
+            }
+
+            if (!extract && WiiSupport.TryRepackWiiContainer(inputFile, fi.DirectoryName, MainMenu.settings.pathForOutputFolder, out wiiResult))
+            {
+                return wiiResult;
+            }
+
             byte[] vectorFont = null;
             int vecFontSize = -1;
             string modFile = Methods.GetNameOfFileOnly(inputFile, ".font") + ".ttf";

--- a/master/Graphics/TextureWorker.cs
+++ b/master/Graphics/TextureWorker.cs
@@ -879,7 +879,7 @@ namespace TTG_Tools.Graphics
             FileInfo fi = new FileInfo(InputFile);
 
             string ext = fi.Extension.ToLowerInvariant();
-            if ((ext == ".d3dtx" || ext == ".font"))
+            if (MainMenu.settings.swizzleNintendoWii && (ext == ".d3dtx" || ext == ".font"))
             {
                 string wiiResult;
                 if (extract && WiiSupport.TryExtractWiiContainer(InputFile, OutputDir, out wiiResult))

--- a/master/Graphics/TextureWorker.cs
+++ b/master/Graphics/TextureWorker.cs
@@ -878,6 +878,28 @@ namespace TTG_Tools.Graphics
 
             FileInfo fi = new FileInfo(InputFile);
 
+            string ext = fi.Extension.ToLowerInvariant();
+            if ((ext == ".d3dtx" || ext == ".font"))
+            {
+                string wiiResult;
+                if (extract && WiiSupport.TryExtractWiiContainer(InputFile, OutputDir, out wiiResult))
+                {
+                    return wiiResult;
+                }
+
+                if (!extract && WiiSupport.TryRepackWiiContainer(InputFile, fi.DirectoryName, OutputDir, out wiiResult))
+                {
+                    if (FullEncrypt && EncKey != null)
+                    {
+                        string outPath = Path.Combine(OutputDir, fi.Name);
+                        byte[] encryptedData = File.ReadAllBytes(outPath);
+                        Methods.meta_crypt(encryptedData, EncKey, version, false);
+                        File.WriteAllBytes(outPath, encryptedData);
+                    }
+                    return wiiResult;
+                }
+            }
+
             byte[] binContent = File.ReadAllBytes(InputFile);
             byte[] check_header = new byte[4];
             Array.Copy(binContent, 0, check_header, 0, check_header.Length);

--- a/master/Graphics/WiiSupport.cs
+++ b/master/Graphics/WiiSupport.cs
@@ -1,0 +1,568 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace TTG_Tools.Graphics
+{
+    internal static class WiiSupport
+    {
+        internal struct Resolution
+        {
+            public int Width;
+            public int Height;
+        }
+
+        private static readonly byte[] HeaderMagic = Encoding.ASCII.GetBytes("ERTM");
+        private static readonly byte[] TplMagic = { 0x00, 0x20, 0xAF, 0x30 };
+        private static readonly byte[] HashStyleMagic = { 0x81, 0x53, 0x37, 0x63, 0x9E, 0x4A, 0x3A, 0x9A };
+        private static readonly byte[] SomeTexDataHash = { 0xE3, 0x88, 0x09, 0x7A, 0x48, 0x5D, 0x7F, 0x93 };
+
+        internal class WiiGlyph
+        {
+            public int TexNum;
+            public float XStart;
+            public float XEnd;
+            public float YStart;
+            public float YEnd;
+            public float CharWidth;
+            public float CharHeight;
+        }
+
+        internal class WiiFontData
+        {
+            public byte[] SignatureBytes = HeaderMagic;
+            public byte[] ElementsDataBytes = new byte[0];
+            public byte[] FontNameBlockBytes = new byte[0];
+            public byte[] FontMetadataAfterNameBytes = new byte[0];
+            public byte[] OptionalOneValueBytes;
+            public byte[] BlockCoordSizeValBytes;
+            public byte[] CharCountValBytes = new byte[0];
+            public byte[] RawGlyphDataBytes = new byte[0];
+            public byte[] SuffixDataBytes = new byte[0];
+            public string FontName = string.Empty;
+            public float BaseSize;
+            public bool IsBlockSizeFont;
+            public bool HasScaleValue;
+            public int CharCount;
+            public int TextureWidth;
+            public int TextureHeight;
+            public int TexCount = 1;
+            public readonly List<WiiGlyph> Glyphs = new List<WiiGlyph>();
+
+            public void Parse(string path, int texWidth, int texHeight)
+            {
+                TextureWidth = texWidth;
+                TextureHeight = texHeight;
+                bool preliminaryHasScale = false;
+
+                using (var fs = new FileStream(path, FileMode.Open, FileAccess.Read))
+                using (var br = new BinaryReader(fs))
+                {
+                    SignatureBytes = br.ReadBytes(4);
+                    if (!SignatureBytes.SequenceEqual(HeaderMagic)) throw new InvalidDataException("Not an ERTM file.");
+
+                    byte[] countElementBytes = br.ReadBytes(4);
+                    int countElements = BitConverter.ToInt32(countElementBytes, 0);
+                    var elementBytes = new List<byte[]> { countElementBytes };
+                    var elementContentForCheck = new List<byte[]>();
+
+                    if (countElements > 0)
+                    {
+                        byte[] peek = br.ReadBytes(8);
+                        fs.Seek(-8, SeekOrigin.Current);
+                        bool allHash = peek.SequenceEqual(HashStyleMagic);
+
+                        for (int i = 0; i < countElements; i++)
+                        {
+                            if (allHash)
+                            {
+                                byte[] hashPart = br.ReadBytes(8);
+                                byte[] padPart = br.ReadBytes(4);
+                                elementBytes.Add(hashPart);
+                                elementBytes.Add(padPart);
+                                elementContentForCheck.Add(hashPart);
+                            }
+                            else
+                            {
+                                byte[] lenBytes = br.ReadBytes(4);
+                                int len = BitConverter.ToInt32(lenBytes, 0);
+                                byte[] strBytes = br.ReadBytes(len);
+                                byte[] toolBytes = br.ReadBytes(4);
+                                elementBytes.Add(lenBytes);
+                                elementBytes.Add(strBytes);
+                                elementBytes.Add(toolBytes);
+                                elementContentForCheck.Add(strBytes);
+                            }
+                        }
+                    }
+
+                    ElementsDataBytes = Concat(elementBytes);
+                    preliminaryHasScale = elementContentForCheck.Any(x => x.SequenceEqual(SomeTexDataHash));
+
+                    long fontNameStart = fs.Position;
+                    byte[] possibleBlockSizeBytes = br.ReadBytes(4);
+                    int possibleBlockSize = BitConverter.ToInt32(possibleBlockSizeBytes, 0);
+
+                    long afterFirst = fs.Position;
+                    byte[] maybeNameLenBytes = br.ReadBytes(4);
+                    byte[] actualNameLenBytes;
+
+                    if (maybeNameLenBytes.Length < 4)
+                    {
+                        IsBlockSizeFont = false;
+                        actualNameLenBytes = possibleBlockSizeBytes;
+                        fs.Seek(afterFirst, SeekOrigin.Begin);
+                    }
+                    else
+                    {
+                        int maybeNameLen = BitConverter.ToInt32(maybeNameLenBytes, 0);
+                        if (possibleBlockSize > 0 && maybeNameLen >= 0 && possibleBlockSize - maybeNameLen == 8)
+                        {
+                            IsBlockSizeFont = true;
+                            actualNameLenBytes = maybeNameLenBytes;
+                        }
+                        else
+                        {
+                            IsBlockSizeFont = false;
+                            actualNameLenBytes = possibleBlockSizeBytes;
+                            fs.Seek(afterFirst, SeekOrigin.Begin);
+                        }
+                    }
+
+                    int nameLen = BitConverter.ToInt32(actualNameLenBytes, 0);
+                    byte[] nameBytes = br.ReadBytes(nameLen);
+                    FontName = Encoding.ASCII.GetString(nameBytes);
+
+                    long nameEnd = fs.Position;
+                    fs.Seek(fontNameStart, SeekOrigin.Begin);
+                    FontNameBlockBytes = br.ReadBytes((int)(nameEnd - fontNameStart));
+
+                    long metadataStart = fs.Position;
+                    br.ReadByte();
+                    BaseSize = br.ReadSingle();
+                    int consumed = 5;
+
+                    long peekStart = fs.Position;
+                    byte[] peekOptional = br.ReadBytes(4);
+                    if (peekOptional.Length == 4 && peekOptional.SequenceEqual(new byte[] { 0xCE, 0xFA, 0xED, 0xFE }))
+                    {
+                        consumed += 4;
+                        peekStart = fs.Position;
+                        peekOptional = br.ReadBytes(4);
+                    }
+
+                    if (peekOptional.Length == 4)
+                    {
+                        float half = BitConverter.ToSingle(peekOptional, 0);
+                        if (Math.Abs(half - 0.5f) < 0.00001f || Math.Abs(half - 1.0f) < 0.00001f) consumed += 4;
+                        else fs.Seek(peekStart, SeekOrigin.Begin);
+                    }
+
+                    fs.Seek(metadataStart, SeekOrigin.Begin);
+                    FontMetadataAfterNameBytes = br.ReadBytes(consumed);
+                    fs.Seek(metadataStart + consumed, SeekOrigin.Begin);
+
+                    if (IsBlockSizeFont && preliminaryHasScale)
+                    {
+                        OptionalOneValueBytes = br.ReadBytes(4);
+                        if (OptionalOneValueBytes.Length < 4) OptionalOneValueBytes = null;
+                    }
+
+                    int blockCoordSizeParsed = 0;
+                    if (IsBlockSizeFont)
+                    {
+                        BlockCoordSizeValBytes = br.ReadBytes(4);
+                        blockCoordSizeParsed = BitConverter.ToInt32(BlockCoordSizeValBytes, 0);
+                    }
+
+                    CharCountValBytes = br.ReadBytes(4);
+                    CharCount = BitConverter.ToInt32(CharCountValBytes, 0);
+
+                    if (IsBlockSizeFont && CharCount > 0)
+                    {
+                        float perGlyph = (blockCoordSizeParsed - 8f) / CharCount;
+                        HasScaleValue = Math.Abs(perGlyph - 28f) < 0.001f;
+                    }
+                    else
+                    {
+                        HasScaleValue = preliminaryHasScale;
+                    }
+
+                    int bytesPerGlyph = HasScaleValue ? 28 : 20;
+                    int glyphTotal = CharCount * bytesPerGlyph;
+                    RawGlyphDataBytes = br.ReadBytes(glyphTotal);
+
+                    using (var ms = new MemoryStream(RawGlyphDataBytes))
+                    using (var gbr = new BinaryReader(ms))
+                    {
+                        Glyphs.Clear();
+                        for (int i = 0; i < CharCount; i++)
+                        {
+                            var g = new WiiGlyph();
+                            g.TexNum = gbr.ReadInt32();
+                            float x0 = gbr.ReadSingle();
+                            float x1 = gbr.ReadSingle();
+                            float y0 = gbr.ReadSingle();
+                            float y1 = gbr.ReadSingle();
+                            g.XStart = (float)Math.Round(x0 * TextureWidth);
+                            g.XEnd = (float)Math.Round(x1 * TextureWidth);
+                            g.YStart = (float)Math.Round(y0 * TextureHeight);
+                            g.YEnd = (float)Math.Round(y1 * TextureHeight);
+                            if (HasScaleValue)
+                            {
+                                g.CharWidth = (float)Math.Round(gbr.ReadSingle());
+                                g.CharHeight = (float)Math.Round(gbr.ReadSingle());
+                            }
+                            Glyphs.Add(g);
+                        }
+                    }
+
+                    long suffixStart = fs.Position;
+                    fs.Seek(0, SeekOrigin.End);
+                    long end = fs.Position;
+                    fs.Seek(suffixStart, SeekOrigin.Begin);
+                    SuffixDataBytes = br.ReadBytes((int)(end - suffixStart));
+                }
+            }
+
+            public void Save(string outputPath)
+            {
+                using (var ms = new MemoryStream())
+                using (var bw = new BinaryWriter(ms))
+                {
+                    foreach (var g in Glyphs)
+                    {
+                        bw.Write(g.TexNum);
+                        bw.Write(TextureWidth == 0 ? 0f : g.XStart / TextureWidth);
+                        bw.Write(TextureWidth == 0 ? 0f : g.XEnd / TextureWidth);
+                        bw.Write(TextureHeight == 0 ? 0f : g.YStart / TextureHeight);
+                        bw.Write(TextureHeight == 0 ? 0f : g.YEnd / TextureHeight);
+                        if (HasScaleValue)
+                        {
+                            bw.Write(g.CharWidth);
+                            bw.Write(g.CharHeight);
+                        }
+                    }
+
+                    byte[] glyphBytes = ms.ToArray();
+                    using (var fs = new FileStream(outputPath, FileMode.Create, FileAccess.Write))
+                    using (var outBw = new BinaryWriter(fs))
+                    {
+                        outBw.Write(SignatureBytes);
+                        outBw.Write(ElementsDataBytes);
+                        outBw.Write(FontNameBlockBytes);
+                        outBw.Write(FontMetadataAfterNameBytes);
+                        if (OptionalOneValueBytes != null) outBw.Write(OptionalOneValueBytes);
+                        if (IsBlockSizeFont)
+                        {
+                            int bytesPerGlyph = HasScaleValue ? 28 : 20;
+                            int recalculated = (CharCount * bytesPerGlyph) + 8;
+                            outBw.Write(recalculated);
+                        }
+                        outBw.Write(CharCountValBytes);
+                        outBw.Write(glyphBytes);
+                        outBw.Write(SuffixDataBytes);
+                    }
+                }
+            }
+
+            public void ExportFnt(string path)
+            {
+                using (var sw = new StreamWriter(path, false, Encoding.UTF8))
+                {
+                    sw.WriteLine("info face=\"{0}\" size={1} bold=0 italic=0 charset=\"\" unicode=0 smooth=0 aa=0 padding=0,0,0,0 spacing=0,0 outline=0", FontName, (int)BaseSize);
+                    sw.WriteLine("common lineHeight={0} base={0} scaleW={1} scaleH={2} pages={3} packed=0 alphaChnl=0 redChnl=0 greenChnl=0 blueChnl=0", (int)BaseSize, TextureWidth, TextureHeight, TexCount);
+                    for (int i = 0; i < TexCount; i++) sw.WriteLine("page id={0} file=\"{1}_{0}.dds\"", i, FontName);
+                    sw.WriteLine("chars count={0}", Glyphs.Count);
+
+                    for (int i = 0; i < Glyphs.Count; i++)
+                    {
+                        var g = Glyphs[i];
+                        int width = HasScaleValue ? (int)g.CharWidth : (int)(g.XEnd - g.XStart);
+                        int height = HasScaleValue ? (int)g.CharHeight : (int)(g.YEnd - g.YStart);
+                        sw.WriteLine("char id={0,-5} x={1,-5} y={2,-5} width={3,-5} height={4,-5} xoffset=0    yoffset=0    xadvance={5,-5} page={6,-3} chnl=15", i, (int)g.XStart, (int)g.YStart, width, height, width, g.TexNum);
+                    }
+                }
+            }
+
+            public void ImportFnt(string path)
+            {
+                var map = new Dictionary<int, WiiGlyph>();
+                int maxId = -1;
+                foreach (string line in File.ReadLines(path))
+                {
+                    string trimmed = line.Trim();
+                    if (trimmed.StartsWith("common "))
+                    {
+                        var data = ParseFntPairs(trimmed);
+                        if (data.ContainsKey("pages")) TexCount = ParseInt(data["pages"]);
+                    }
+                    else if (trimmed.StartsWith("char "))
+                    {
+                        var data = ParseFntPairs(trimmed);
+                        int id = ParseInt(data["id"]);
+                        maxId = Math.Max(maxId, id);
+                        var g = new WiiGlyph
+                        {
+                            TexNum = ParseInt(data["page"]),
+                            XStart = ParseFloat(data["x"]),
+                            YStart = ParseFloat(data["y"])
+                        };
+                        float width = ParseFloat(data["width"]);
+                        float height = ParseFloat(data["height"]);
+                        g.XEnd = g.XStart + width;
+                        g.YEnd = g.YStart + height;
+                        if (HasScaleValue)
+                        {
+                            g.CharWidth = width;
+                            g.CharHeight = height;
+                        }
+                        map[id] = g;
+                    }
+                }
+
+                if (maxId + 1 != CharCount)
+                {
+                    // keep original size, just partial replacement
+                }
+
+                for (int i = 0; i < CharCount; i++)
+                {
+                    WiiGlyph g;
+                    if (map.TryGetValue(i, out g)) Glyphs[i] = g;
+                }
+            }
+        }
+
+        internal static bool TryExtractWiiContainer(string inputPath, string outputDir, out string result)
+        {
+            result = null;
+            byte[] data; int version; int offSizes; List<int> tplOffsets; bool alt;
+            if (!TryParseContainer(inputPath, out data, out version, out offSizes, out tplOffsets, out alt)) return false;
+
+            string name = Path.GetFileNameWithoutExtension(inputPath);
+            string ext = Path.GetExtension(inputPath).ToLowerInvariant();
+
+            int size1 = BitConverter.ToInt32(data, offSizes);
+            File.WriteAllBytes(Path.Combine(outputDir, name + ".tpl"), Slice(data, tplOffsets[0], size1));
+
+            if (ext == ".font")
+            {
+                var res = ReadTplResolution(data, tplOffsets[0]);
+                if (res.HasValue)
+                {
+                    var font = new WiiFontData();
+                    font.Parse(inputPath, res.Value.Width, res.Value.Height);
+                    font.ExportFnt(Path.Combine(outputDir, name + ".fnt"));
+                }
+            }
+
+            if (!(version == 4 && alt) && (version == 4 || version == 7) && tplOffsets.Count > 1)
+            {
+                int size2 = BitConverter.ToInt32(data, offSizes + 4);
+                if (size2 > 0) File.WriteAllBytes(Path.Combine(outputDir, name + "_alpha.tpl"), Slice(data, tplOffsets[1], size2));
+            }
+
+            result = "File " + Path.GetFileName(inputPath) + " successfully extracted (Wii/TPL).";
+            return true;
+        }
+
+        internal static bool TryRepackWiiContainer(string inputPath, string inputDir, string outputDir, out string result)
+        {
+            result = null;
+            byte[] data; int version; int offSizes; List<int> tplOffsets; bool alt;
+            if (!TryParseContainer(inputPath, out data, out version, out offSizes, out tplOffsets, out alt)) return false;
+
+            string name = Path.GetFileNameWithoutExtension(inputPath);
+            string ext = Path.GetExtension(inputPath).ToLowerInvariant();
+            string tplPath = Path.Combine(inputDir, name + ".tpl");
+            if (!File.Exists(tplPath)) return false;
+
+            byte[] tpl1 = File.ReadAllBytes(tplPath);
+            byte[] tpl2 = new byte[0];
+            if ((version == 4 || version == 7) && !(version == 4 && alt))
+            {
+                string alphaPath = Path.Combine(inputDir, name + "_alpha.tpl");
+                if (File.Exists(alphaPath)) tpl2 = File.ReadAllBytes(alphaPath);
+            }
+
+            int tplStart = tplOffsets[0];
+            byte[] prefix = new byte[tplStart];
+            Array.Copy(data, 0, prefix, 0, prefix.Length);
+            Array.Copy(BitConverter.GetBytes(tpl1.Length), 0, prefix, offSizes, 4);
+            if ((version == 4 || version == 7) && !(version == 4 && alt)) Array.Copy(BitConverter.GetBytes(tpl2.Length), 0, prefix, offSizes + 4, 4);
+
+            byte[] newData = Concat(new[] { prefix, tpl1, tpl2 });
+            string outPath = Path.Combine(outputDir, name + ext);
+            File.WriteAllBytes(outPath, newData);
+
+            if (ext == ".font")
+            {
+                string fntPath = Path.Combine(inputDir, name + ".fnt");
+                var res = ReadTplResolution(newData, tplOffsets[0]);
+                if (File.Exists(fntPath) && res.HasValue)
+                {
+                    var font = new WiiFontData();
+                    font.Parse(outPath, res.Value.Width, res.Value.Height);
+                    font.ImportFnt(fntPath);
+                    font.Save(outPath);
+                }
+            }
+
+            result = "File " + Path.GetFileName(inputPath) + " successfully imported (Wii/TPL).";
+            return true;
+        }
+
+        internal static bool TryLoadWiiFontForEditor(string fontPath, out WiiFontData fontData)
+        {
+            fontData = null;
+            byte[] data; int version; int offSizes; List<int> tplOffsets; bool alt;
+            if (!TryParseContainer(fontPath, out data, out version, out offSizes, out tplOffsets, out alt)) return false;
+            if (Path.GetExtension(fontPath).ToLowerInvariant() != ".font") return false;
+            var res = ReadTplResolution(data, tplOffsets[0]);
+            if (!res.HasValue) return false;
+            var parsed = new WiiFontData();
+            parsed.Parse(fontPath, res.Value.Width, res.Value.Height);
+            fontData = parsed;
+            return true;
+        }
+
+        private static bool TryParseContainer(string path, out byte[] data, out int version, out int offSizes, out List<int> tplOffsets, out bool alt)
+        {
+            data = File.ReadAllBytes(path);
+            version = 0;
+            offSizes = 0;
+            tplOffsets = new List<int>();
+            alt = false;
+
+            if (data.Length < 8 || !Slice(data, 0, 4).SequenceEqual(HeaderMagic)) return false;
+
+            version = BitConverter.ToInt32(data, 4);
+            if (version == 4)
+            {
+                int @base = 64;
+                int length = BitConverter.ToInt32(data, @base);
+                int prefixBase = @base + 4 + length;
+                int normalOffset = prefixBase + 0x2C;
+                int sizeAtNormal = BitConverter.ToInt32(data, normalOffset);
+                offSizes = sizeAtNormal == 0 ? (prefixBase + 0xA6) : normalOffset;
+                alt = sizeAtNormal == 0;
+            }
+            else if (version == 2)
+            {
+                int @base = 32;
+                int length = BitConverter.ToInt32(data, @base);
+                offSizes = @base + 4 + length + 0x2B;
+            }
+            else if (version == 7 || version == 5)
+            {
+                byte[] dxt = Encoding.ASCII.GetBytes("DXT");
+                int idx = IndexOf(data, dxt);
+                if (idx < 0) return false;
+                offSizes = idx + (version == 7 ? 0x21 : 0x1D);
+            }
+            else return false;
+
+            tplOffsets = FindAll(data, TplMagic);
+            return tplOffsets.Count > 0;
+        }
+
+        private static Resolution? ReadTplResolution(byte[] data, int tplOffset)
+        {
+            try
+            {
+                if (tplOffset + 12 > data.Length) return null;
+                uint id = ReadUInt32BE(data, tplOffset);
+                if (id != 0x0020AF30) return null;
+                uint images = ReadUInt32BE(data, tplOffset + 4);
+                uint tableOffset = ReadUInt32BE(data, tplOffset + 8);
+                if (images == 0) return null;
+                uint imgHeaderOffset = ReadUInt32BE(data, tplOffset + (int)tableOffset);
+                ushort height = ReadUInt16BE(data, tplOffset + (int)imgHeaderOffset);
+                ushort width = ReadUInt16BE(data, tplOffset + (int)imgHeaderOffset + 2);
+                Resolution r = new Resolution();
+                r.Width = width * 2;
+                r.Height = height * 2;
+                return r;
+            }
+            catch { return null; }
+        }
+
+        private static Dictionary<string, string> ParseFntPairs(string line)
+        {
+            var dict = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+            string[] parts = line.Split(new[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            foreach (string part in parts.Skip(1))
+            {
+                int idx = part.IndexOf('=');
+                if (idx <= 0) continue;
+                dict[part.Substring(0, idx)] = part.Substring(idx + 1).Trim('"');
+            }
+            return dict;
+        }
+
+        private static int ParseInt(string value) { return int.Parse(value, CultureInfo.InvariantCulture); }
+        private static float ParseFloat(string value) { return float.Parse(value, CultureInfo.InvariantCulture); }
+
+        private static ushort ReadUInt16BE(byte[] data, int offset) { return (ushort)((data[offset] << 8) | data[offset + 1]); }
+        private static uint ReadUInt32BE(byte[] data, int offset) { return (uint)((data[offset] << 24) | (data[offset + 1] << 16) | (data[offset + 2] << 8) | data[offset + 3]); }
+
+        private static byte[] Slice(byte[] source, int offset, int len)
+        {
+            if (offset < 0 || len < 0 || offset + len > source.Length) return new byte[0];
+            byte[] result = new byte[len];
+            Array.Copy(source, offset, result, 0, len);
+            return result;
+        }
+
+        private static byte[] Concat(IEnumerable<byte[]> arrays)
+        {
+            int len = 0;
+            foreach (byte[] a in arrays)
+            {
+                if (a != null) len += a.Length;
+            }
+            byte[] output = new byte[len];
+            int pos = 0;
+            foreach (byte[] arr in arrays)
+            {
+                if (arr == null) continue;
+                Buffer.BlockCopy(arr, 0, output, pos, arr.Length);
+                pos += arr.Length;
+            }
+            return output;
+        }
+
+        private static int IndexOf(byte[] data, byte[] target)
+        {
+            for (int i = 0; i <= data.Length - target.Length; i++)
+            {
+                bool ok = true;
+                for (int j = 0; j < target.Length; j++)
+                {
+                    if (data[i + j] != target[j]) { ok = false; break; }
+                }
+                if (ok) return i;
+            }
+            return -1;
+        }
+
+        private static List<int> FindAll(byte[] data, byte[] target)
+        {
+            var offsets = new List<int>();
+            for (int i = 0; i <= data.Length - target.Length; i++)
+            {
+                bool ok = true;
+                for (int j = 0; j < target.Length; j++)
+                {
+                    if (data[i + j] != target[j]) { ok = false; break; }
+                }
+                if (ok) offsets.Add(i);
+            }
+            return offsets;
+        }
+    }
+}

--- a/master/MainMenu.cs
+++ b/master/MainMenu.cs
@@ -10,7 +10,7 @@ namespace TTG_Tools
 {
     public partial class MainMenu : Form
     {
-        public static Settings settings = new Settings("", "", 1251, false, false, false, true, false, 0, false, false, false, false, false, false, 0, 0, "", "", "", false, false, false, false, 0, 0, false, false, false, false, false, false, false, false, -1, false);
+        public static Settings settings = new Settings("", "", 1251, false, false, false, true, false, 0, false, false, false, false, false, false, 0, 0, "", "", "", false, false, false, false, 0, 0, false, false, false, false, false, false, false, false, false, -1, false);
 
         [DllImport("kernel32.dll")]
         public static extern void SetProcessWorkingSetSize(IntPtr hWnd, int i, int j);

--- a/master/Settings.cs
+++ b/master/Settings.cs
@@ -53,6 +53,7 @@ namespace TTG_Tools
         private bool _swizzlePS4;
         private bool _swizzleXbox360;
         private bool _swizzlePSVita;
+        private bool _swizzleNintendoWii;
         private bool _supportTwdNintendoSwitch;
 
         private int _languageIndex;
@@ -500,6 +501,19 @@ namespace TTG_Tools
             }
         }
 
+        [XmlAttribute("swizzleNintendoWii")]
+        public bool swizzleNintendoWii
+        {
+            get
+            {
+                return _swizzleNintendoWii;
+            }
+            set
+            {
+                _swizzleNintendoWii = value;
+            }
+        }
+
         [XmlAttribute("ASCIILanguageIndex")]
         public int languageIndex
         {
@@ -561,6 +575,7 @@ namespace TTG_Tools
             bool _swizzlePS4,
             bool _swizzleXbox360,
             bool _swizzlePSVita,
+            bool _swizzleNintendoWii,
             int _languageIndex,
             bool _supportTwdNintendoSwitch)
         {
@@ -598,6 +613,7 @@ namespace TTG_Tools
             this.swizzlePS4 = _swizzlePS4;
             this.swizzleXbox360 = _swizzleXbox360;
             this.swizzlePSVita = _swizzlePSVita;
+            this.swizzleNintendoWii = _swizzleNintendoWii;
             this.languageIndex = _languageIndex;
             this.supportTwdNintendoSwitch = _supportTwdNintendoSwitch;
         }

--- a/master/TTG Tools.csproj
+++ b/master/TTG Tools.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Graphics\DDS\Flags.cs" />
     <Compile Include="Graphics\DDS\SomeActions.cs" />
     <Compile Include="Graphics\FontWorker.cs" />
+    <Compile Include="Graphics\WiiSupport.cs" />
     <Compile Include="Graphics\PVR\pvr.cs" />
     <Compile Include="Graphics\Swizzles\PS4.cs" />
     <Compile Include="Graphics\Swizzles\PSVita.cs" />


### PR DESCRIPTION
### Motivation

* Allow Auto(De)Packer and the Font Editor to handle Nintendo Wii containers that embed TPLs (`ERTM`), enabling extraction/repacking of textures and synchronization of font coordinates.
* Reuse the font editing tool to open Wii `.font` files, export them to `.fnt` for editing, and reimport them without losing the original container.

### Description

* Adds a new helper `WiiSupport` in `master/Graphics/WiiSupport.cs` that detects/parses `ERTM` containers, locates `TPL` offsets, reads TPL resolution, extracts/repacks `.tpl`/`_alpha.tpl`, and imports/exports `.fnt`/glyph data.
* Integrates the Wii workflow into `TextureWorker.DoWork` to intercept `.d3dtx` and `.font` before the existing pipeline and apply extraction/repack (with optional re-encryption on import).
* Updates `FontWorker.DoWork` to route Wii files to the new pipeline when applicable and preserve existing behavior for vector fonts.
* Expands `FontEditor` to load Wii fonts (populate coordinate grids and previews) and save changes back into the Wii container using `WiiSupport`.
* Registers `WiiSupport.cs` in `master/TTG Tools.csproj` for inclusion in the build.