### PR TITLE
Adjust Sam & Max Common mod priorities

### DIFF
--- a/master/ModCreator.cs
+++ b/master/ModCreator.cs
@@ -692,7 +692,7 @@ namespace TTG_Tools
                 {
                     new ModLayoutOption { DisplayName = "Boot", ArchiveSegment = "Boot", LogicalName = "Boot", Priority = 10, EnableMode = "bootable", GameDataPriority = 10, DescriptionPriority = 10 },
                     new ModLayoutOption { DisplayName = "UI", ArchiveSegment = "UI", LogicalName = "UI", Priority = 30, EnableMode = "bootable", GameDataPriority = 30, DescriptionPriority = 30 },
-                    new ModLayoutOption { DisplayName = "Common", ArchiveSegment = "Common", LogicalName = "Common", Priority = 100, EnableMode = "bootable", GameDataPriority = 0 },
+                    new ModLayoutOption { DisplayName = "Common", ArchiveSegment = "Common", LogicalName = "Common", Priority = 100, EnableMode = "bootable", GameDataPriority = 100, DescriptionPriority = 100 },
                     new ModLayoutOption { DisplayName = "Menu", ArchiveSegment = "Menu", LogicalName = "Menu", Priority = 20, EnableMode = "bootable", GameDataPriority = 20, DescriptionPriority = 20 },
                     new ModLayoutOption { DisplayName = "Project", ArchiveSegment = "Project", LogicalName = "Project", Priority = -8888, EnableMode = "constant", GameDataPriority = 0 },
                     new ModLayoutOption { DisplayName = "SamMax101", ArchiveSegment = "SamMax101", LogicalName = "SamMax101", Priority = 101, EnableMode = "bootable", GameDataPriority = 101, AppendArchiveSegmentToName = true },


### PR DESCRIPTION
### Motivation
- Ensure the "Common" layout for "Sam & Max: Save the World - Remastered" generates Lua with `set.priority = 100`, `set.descriptionPriority = 100`, and `set.gameDataPriority = 100` by making the layout options reflect those priorities.

### Description
- In `master/ModCreator.cs` updated the `SamAndMaxSaveWorldRemasterProfile.GetLayoutOptions()` entry for `Common` to set `GameDataPriority = 100` and `DescriptionPriority = 100` (the `Priority` was already `100`).